### PR TITLE
Small adaptions

### DIFF
--- a/couchdb.ini
+++ b/couchdb.ini
@@ -3,7 +3,7 @@ users_db_security_editable = true
 [chttpd_auth]
 timeout = 7200
 [jwt_keys]
-rsa:<KID> = -----BEGIN PUBLIC KEY-----\n<PUBLIC_KEY>\n-----END PUBLIC KEY-----
+rsa:<KID>= -----BEGIN PUBLIC KEY-----\n<PUBLIC_KEY>\n-----END PUBLIC KEY-----
 [jwt_auth]
 required_claims = exp
 [chttpd]

--- a/keycloak/client_config.json
+++ b/keycloak/client_config.json
@@ -58,6 +58,19 @@
   "nodeReRegistrationTimeout": -1,
   "protocolMappers": [
     {
+      "name": "username",
+      "protocol": "openid-connect",
+      "protocolMapper": "oidc-usermodel-property-mapper",
+      "consentRequired": false,
+      "config": {
+        "user.attribute": "username",
+        "id.token.claim": "true",
+        "access.token.claim": "true",
+        "claim.name": "username",
+        "userinfo.token.claim": "true"
+      }
+    },
+    {
       "name": "realm roles",
       "protocol": "openid-connect",
       "protocolMapper": "oidc-usermodel-realm-role-mapper",
@@ -72,7 +85,7 @@
       }
     },
     {
-      "name": "username",
+      "name": "exact_username",
       "protocol": "openid-connect",
       "protocolMapper": "oidc-usermodel-attribute-mapper",
       "consentRequired": false,


### PR DESCRIPTION
- fix error in CouchDB JWT auth where the KID was not correctly matched
- made `exact_username` attribute in Keycloak optional