### PR TITLE
Setup script improvement

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+SENTRY_DSN=""

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 This repository describes how to set up everything that is needed to run Aam Digital in production.
 This includes deploying the app, deploying and connecting the database and optionally deploying and connecting the permission backend and keycloak.
 
+## Systems requirements
+The deployment works with minimal requirements. 
+All you need is a system that runs [Docker](https://www.docker.com/) and allows to reach endpoints through a public URL.
+For a single instance a server with **2GB RAM**, a **single CPU** and **20GB disc space** is sufficient.
+With more data and/or more deployments more RAM and CPU power might be necessary or the sync could start to become very slow.
+The required disc space scales with the amount of data and especially images and attachments that are saved in the application.
+
+To monitor the hardware usage [this repo](https://github.com/Aam-Digital/monitoring/blob/main/docker-compose.yml) contains a Prometheus setup.
+This can be connected with [Grafana](https://grafana.com/) to create a system dashboard and trigger alerts on critical performance.
+
 ## Deploying the application
 The interactive script `interactive_setup.sh` walks you through the process of setting up new applications.
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY
 
 ## Adjusting the script
 Some things might need to be adjusted based on how you environment looks.
-Have a look at the following things
+Have a look at the comments at the beginning of the file `interactive_setup.sh`
 
-1. How does the folder translate into the application name (variable `org`)
-2. Domain name for the final applications (variable `url`)
+1. Domain name for the final applications (variable `domain`)
+2. Prefix for created folders (variable `prefix`)
 3. Location of the `.env` file of the keycloak deployment (see section [User management in Keycloak](#user-management-in-keycloak))
 
 # Deploying under a domain name using nginx-proxy
@@ -67,6 +67,6 @@ Once done, applications can be connected with Keycloak through the `interactive_
 *If you just want to use ndb-core through docker, you should not have to build the image yourself. Use the pre-built image on Docker Hub [aamdigital/ndb-server](https://cloud.docker.com/u/aamdigital/repository/docker/aamdigital/ndb-server).*
 
 The Dockerfile to build the image are part of the [ndb-core repository](https://github.com/Aam-Digital/ndb-core).
-See the `/build` subfolder there.
+See the `/build` sub folder there.
 
 The image builds upon a simple nginx webserver and modifies the configuration to include a reverse proxy for the `domain.com/db` URLs to access the CouchDB database from the same domain, avoiding CORS issues.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@ This repository describes how to set up everything that is needed to run Aam Dig
 This includes deploying the app, deploying and connecting the database and optionally deploying and connecting the permission backend and keycloak.
 
 ## Deploying the application
-The interactive script `interactive_setup.sh` walks you through the process of setting up the application.
+The interactive script `interactive_setup.sh` walks you through the process of setting up new applications.
 
-1. Just clone this repository into the folder where you want to start the new instance
-   > git clone https://github.com/Aam-Digital/ndb-setup.git <FOLDER_NAME>
+1. Just clone this repository
 2. Then run the script and follow the questions in the console
-   > cd <FOLDER_NAME> && ./interactive_setup.sh
+   > ./interactive_setup.sh
 
 The following things can be automatically done
 
@@ -17,9 +16,9 @@ The following things can be automatically done
 3. (optional) connect with a running Keycloak
 4. (optional) migrate users from CouchDB to Keycloak
 
-To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `.env` file (which is automatically created after running the `interactive_setup.sh`) to you sentry DSN and restart the container (`docker compose down && docker compose up -d`).
+To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `.env` file to you sentry DSN.
 
-## Adjusting the scrip
+## Adjusting the script
 Some things might need to be adjusted based on how you environment looks.
 Have a look at the following things
 

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -29,8 +29,8 @@ source "/var/docker/nginx-proxy/keycloak/.env"
 echo "What is the name of the organisation?"
 read -r org
 path="../ndb-$org"
-[[ -d "$path" ]] && app=1
-if [ "$app" != 1 ]; then
+app=$(docker ps | grep -c "\-$org-app")
+if [ "$app" == 0 ]; then
   echo "Setting up new instance '$org'"
   mkdir "$path"
   cp .env "$path/.env"
@@ -87,7 +87,7 @@ if [ "$backend" == 0 ]; then
     (cd "$path" && docker compose up -d)
     backend=1
     echo "Backend added"
- elif [ "$app" != 1 ]; then
+ elif [ "$app" == 0 ]; then
     curl -X PUT -u "admin:$COUCHDB_PASSWORD" "https://$APP_URL/db/app/_security" -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }'
     curl -X PUT -u "admin:$COUCHDB_PASSWORD" "https://$APP_URL/db/app-attachments/_security" -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }'
   fi
@@ -132,9 +132,9 @@ if [ ! -f "$path/keycloak.json" ]; then
     fi
 
     echo "App is connected with Keycloak"
-  elif [ "$app" != 1  ]; then
+  elif [ "$app" == 0  ]; then
     curl -X PUT -u "admin:$COUCHDB_PASSWORD" "https://$APP_URL/db/_users"
-    if [ "$backend" != 1 ]; then
+    if [ "$backend" == 0 ]; then
       curl -X PUT -u "admin:$COUCHDB_PASSWORD" "https://$APP_URL/db/_users/_security" -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }'
     fi
 

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -85,7 +85,7 @@ then
     token=$(curl --silent --location "https://$KEYCLOAK_URL/realms/master/protocol/openid-connect/token" --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode username=admin --data-urlencode password="$ADMIN_PASSWORD" --data-urlencode grant_type=password --data-urlencode client_id=admin-cli)
     token=${token#*\"access_token\":\"}
     token=${token%%\"*}
-    curl --silent --location "https://$KEYCLOAK_URL/admin/realms/dev/clients/$client/installation/providers/keycloak-oidc-keycloak-json" --header "Authorization: Bearer $token" > keycloak.json
+    curl --silent --location "https://$KEYCLOAK_URL/admin/realms/$org/clients/$client/installation/providers/keycloak-oidc-keycloak-json" --header "Authorization: Bearer $token" > keycloak.json
     sed -i "s/\"account_url\": \".*\"/\"account_url\": \"https:\/\/$ACCOUNTS_URL\"/g" config-keycloak.json
     cp config-keycloak.json config.json
     sed -i "s/\#\- .\/keycloak/\- .\/keycloak/g" docker-compose.yml

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# These might need to be adjusted based on the setup
+
+# Domain name under which subdomains can be reachable
+domain=aam-digital.com
+# Prefix that will be added to created folders
+prefix=ndb-
+# Location where Keycloak is running
+source "./keycloak/.env"
+
 chars=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 generate_password() {
   password=""
@@ -23,12 +32,9 @@ getKeycloakKey() {
   sed -i "s/\#\- .\/keycloak/\- .\/keycloak/g" "$path/docker-compose.yml"
 }
 
-# This might need to be adjusted, depending where the keycloak is running
-source "/var/docker/setup/keycloak/.env"
-
 echo "What is the name of the organisation?"
 read -r org
-path="../ndb-$org"
+path="../$prefix$org"
 app=$(docker ps | grep -c "\-$org-app")
 if [ "$app" == 0 ]; then
   echo "Setting up new instance '$org'"
@@ -47,8 +53,7 @@ if [ "$app" == 0 ]; then
   echo "COUCHDB_PASSWORD=$password" >> "$path/.env"
   echo "Admin password: $password"
 
-  # might need to be adjusted base on the domain
-  url=$org.aam-digital.com
+  url=$org.$domain
   echo "APP_URL=$url" >> "$path/.env"
   echo "App URL: $url"
   (cd "$path" && docker compose up -d)

--- a/interactive_setup.sh
+++ b/interactive_setup.sh
@@ -24,7 +24,7 @@ getKeycloakKey() {
 }
 
 # This might need to be adjusted, depending where the keycloak is running
-source "/var/docker/nginx-proxy/keycloak/.env"
+source "/var/docker/setup/keycloak/.env"
 
 echo "What is the name of the organisation?"
 read -r org

--- a/keycloak/client_config.json
+++ b/keycloak/client_config.json
@@ -58,19 +58,6 @@
   "nodeReRegistrationTimeout": -1,
   "protocolMappers": [
     {
-      "name": "username",
-      "protocol": "openid-connect",
-      "protocolMapper": "oidc-usermodel-property-mapper",
-      "consentRequired": false,
-      "config": {
-        "user.attribute": "username",
-        "id.token.claim": "true",
-        "access.token.claim": "true",
-        "claim.name": "username",
-        "userinfo.token.claim": "true"
-      }
-    },
-    {
       "name": "realm roles",
       "protocol": "openid-connect",
       "protocolMapper": "oidc-usermodel-realm-role-mapper",


### PR DESCRIPTION
Also see #15 

Some bugs in the script have been fixed and it also has been refactored so only one `ndb-setup` repository is required per server. The script is then executed from this folder and creates the required deployments.

It can do the following tasks:

- Create a new instance
  - (optional) with permission backend
  - (optional) with Keycloak
- Update a existing instance
  - (optional) with permission backend
  - (optional) with Keycloak
  - (optional) migrate users from CouchDB