### PR TITLE
Improved templates

### DIFF
--- a/keycloak/aam-theme/email/html/code-email.ftl
+++ b/keycloak/aam-theme/email/html/code-email.ftl
@@ -1,8 +1,6 @@
-<html>
-<body>
-<h1 style="color: #ff9800">Aam Digital - ${realmName}</h1>
+<#import "template.ftl" as layout>
+<@layout.emailLayout>
 ${kcSanitize(msg("emailCodeBodyHtml", ttl))}
 <h2>${code}</h2>
-${kcSanitize(msg("emailFooterHtml"))?no_esc}
-</body>
-</html>
+</@layout.emailLayout>
+

--- a/keycloak/aam-theme/email/html/executeActions.ftl
+++ b/keycloak/aam-theme/email/html/executeActions.ftl
@@ -3,10 +3,8 @@
 <#assign requiredActionsValues><#if requiredActions??><#list requiredActions><#items as reqActionItem>${reqActionItem}<#sep>, </#sep></#items></#list></#if></#assign>
 </#outputformat>
 
-
-<html>
-<body>
-<h1 style="color: #ff9800">${realmName}</h1>
+<#import "template.ftl" as layout>
+<@layout.emailLayout>
 <#if requiredActionsValues == "VERIFY_EMAIL">
 ${kcSanitize(msg("emailVerificationBodyHtml", link, user.getAttributes().exact_username, link?keep_after("realms/")?keep_before("/"), linkExpirationFormatter(linkExpiration)))?no_esc}
 <#elseif requiredActionsValues == "UPDATE_PASSWORD">
@@ -14,6 +12,4 @@ ${kcSanitize(msg("passwordResetBodyHtml", link, user.getAttributes().exact_usern
 <#else>
 ${kcSanitize(msg("executeActionsBodyHtml", link, linkExpiration, realmName, requiredActionsText, linkExpirationFormatter(linkExpiration)))?no_esc}
 </#if>
-${kcSanitize(msg("emailFooterHtml"))?no_esc}
-</body>
-</html>
+</@layout.emailLayout>

--- a/keycloak/aam-theme/email/html/executeActions.ftl
+++ b/keycloak/aam-theme/email/html/executeActions.ftl
@@ -6,11 +6,11 @@
 
 <html>
 <body>
-<h1 style="color: #ff9800">Aam Digital - ${realmName}</h1>
+<h1 style="color: #ff9800">${realmName}</h1>
 <#if requiredActionsValues == "VERIFY_EMAIL">
-${kcSanitize(msg("emailVerificationBodyHtml", link, user.username, realmName, linkExpirationFormatter(linkExpiration)))?no_esc}
+${kcSanitize(msg("emailVerificationBodyHtml", link, user.getAttributes().exact_username, link?keep_after("realms/")?keep_before("/"), linkExpirationFormatter(linkExpiration)))?no_esc}
 <#elseif requiredActionsValues == "UPDATE_PASSWORD">
-${kcSanitize(msg("passwordResetBodyHtml", link, user.username, realmName, linkExpirationFormatter(linkExpiration)))?no_esc}
+${kcSanitize(msg("passwordResetBodyHtml", link, user.getAttributes().exact_username, link?keep_after("realms/")?keep_before("/"), linkExpirationFormatter(linkExpiration)))?no_esc}
 <#else>
 ${kcSanitize(msg("executeActionsBodyHtml", link, linkExpiration, realmName, requiredActionsText, linkExpirationFormatter(linkExpiration)))?no_esc}
 </#if>

--- a/keycloak/aam-theme/email/html/template.ftl
+++ b/keycloak/aam-theme/email/html/template.ftl
@@ -1,0 +1,9 @@
+<#macro emailLayout>
+<html>
+<body>
+    <h1 style="color: #ff9800">${realmName}</h1>
+    <#nested>
+    ${kcSanitize(msg("emailFooterHtml"))?no_esc}
+</body>
+</html>
+</#macro>


### PR DESCRIPTION
- [x] When realm display name is changed, the link to the application is broken
- [x] When realm display name includes `Aam Digital - ` the email title was weird
- [x] Using email template to standardize layout 