### PR TITLE
fix: simplify SWAG proxy — remove redundant locations, add network aliases for routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,6 @@ services:
       - ./config.json:/usr/share/nginx/html/assets/config.json
       - ./keycloak.json:/usr/share/nginx/html/assets/keycloak.json
       - ./firebase-config.json:/usr/share/nginx/html/assets/firebase-config.json
-    environment:
-      COUCHDB_URL: http://${INSTANCE_NAME}-db-entrypoint:5984
-      QUERY_URL: http://${INSTANCE_NAME}-aam-backend-service:8080
     restart: unless-stopped
 
   couchdb-only:
@@ -19,8 +16,10 @@ services:
     container_name: ${INSTANCE_NAME}-db-entrypoint
     user: "1000:1000"
     networks:
-      - internal_aam
-      - external_web
+      internal_aam:
+        aliases:
+          - db-entrypoint
+      external_web:
     volumes:
       - ./couchdb/data:/opt/couchdb/data
       - ./couchdb.ini:/opt/couchdb/etc/local.d/couchdb.ini
@@ -54,8 +53,10 @@ services:
     image: ghcr.io/aam-digital/replication-backend:${AAM_REPLICATION_BACKEND_VERSION:-latest}
     container_name: ${INSTANCE_NAME}-db-entrypoint
     networks:
-      - internal_aam
-      - external_web
+      internal_aam:
+        aliases:
+          - db-entrypoint
+      external_web:
     depends_on:
       - couchdb-with-permissions
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - ./config.json:/usr/share/nginx/html/assets/config.json
       - ./keycloak.json:/usr/share/nginx/html/assets/keycloak.json
       - ./firebase-config.json:/usr/share/nginx/html/assets/firebase-config.json
+    environment:
+      COUCHDB_URL: http://${INSTANCE_NAME}-db-entrypoint:5984
+      QUERY_URL: http://${INSTANCE_NAME}-aam-backend-service:8080
     restart: unless-stopped
 
   couchdb-only:

--- a/swag-proxy/aam-prod-2/config/nginx/proxy-confs/instance.app.subdomain.conf
+++ b/swag-proxy/aam-prod-2/config/nginx/proxy-confs/instance.app.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }

--- a/swag-proxy/aam-prod-2/config/nginx/proxy-confs/instance.com.subdomain.conf
+++ b/swag-proxy/aam-prod-2/config/nginx/proxy-confs/instance.com.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }

--- a/swag-proxy/aam-prod-3/config/nginx/proxy-confs/instance.app.subdomain.conf
+++ b/swag-proxy/aam-prod-3/config/nginx/proxy-confs/instance.app.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }

--- a/swag-proxy/aam-prod-3/config/nginx/proxy-confs/instance.com.subdomain.conf
+++ b/swag-proxy/aam-prod-3/config/nginx/proxy-confs/instance.com.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }

--- a/swag-proxy/aam-prod-4/config/nginx/proxy-confs/instance.app.subdomain.conf
+++ b/swag-proxy/aam-prod-4/config/nginx/proxy-confs/instance.app.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }

--- a/swag-proxy/aam-prod-4/config/nginx/proxy-confs/instance.com.subdomain.conf
+++ b/swag-proxy/aam-prod-4/config/nginx/proxy-confs/instance.com.subdomain.conf
@@ -16,43 +16,11 @@ server {
 
     client_max_body_size 25M;
 
-    # forward frontend request to app
+    # forward all requests to app container (handles internal routing for /db, /api, /query, /nominatim)
     location / {
         set $upstream_app "${subdomain}-app";
         set $upstream_port 8080;
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
-    }
-
-    # direct couchdb access, if replication backend is deployed
-    location ~ /db/couchdb/(.*)$ {
-        set $upstream_app "${subdomain}-database";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect database requests to the db-entrypoint (couchDb or replication-backend)
-    location ~ /db/(.*)$ {
-        set $upstream_app "${subdomain}-db-entrypoint";
-        set $upstream_port 5984;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
-    }
-
-    # redirect api calls to aam-backend-service
-    location ~ /api/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/api/$1?$args;
-    }
-
-    # redirect old /query configs to /api
-    location ~ /query/(.*)$ {
-        set $upstream_app "${subdomain}-aam-backend-service";
-        set $upstream_port 8080;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port/$1?$args;
     }
 }


### PR DESCRIPTION
## Summary

Simplify SWAG proxy configs by removing all remaining redundant location blocks, and add Docker network aliases so the app container can route correctly without explicit env vars.

Follow-up to #84 which removed the broken `/nominatim/` location.

### Changes

**SWAG proxy configs** (all 6 files across aam-prod-2, aam-prod-3, aam-prod-4):
- Remove `/db/couchdb/` — handled by replication-backend's internal `/couchdb` proxy
- Remove `/db/` — handled by app container's nginx → `${COUCHDB_URL}`
- Remove `/api/` — handled by app container's nginx → `${QUERY_URL}`
- Remove `/query/` — handled by app container's nginx → `${QUERY_URL}`
- Keep only `/` catch-all forwarding to the app container

**docker-compose.yml**:
- Add `db-entrypoint` network alias to `couchdb-only` and `replication-backend` services on `internal_aam`
- This gives the app container a fixed hostname (`db-entrypoint`) to reach the database, regardless of which profile is active
- `aam-backend-service` is already reachable by its Docker Compose service name

Combined with updated Dockerfile defaults in Aam-Digital/ndb-core#3705 (`COUCHDB_URL=http://db-entrypoint:5984`, `QUERY_URL=http://aam-backend-service:8080`), existing deployments work **without needing to add env vars** to their docker-compose files.

### Why

The SWAG proxy had location blocks that intercepted requests before they reached the app container. This caused:
1. Config drift — routing fixes in ndb-core's `default.conf` were silently overridden by SWAG
2. Maintenance burden — routes had to be kept in sync across two layers
3. The Nominatim 421 bug (Aam-Digital/ndb-core#3684) was a direct consequence of this duplication

With this change, SWAG handles only TLS termination + forwarding to the app container. All path-based routing is owned by ndb-core.

### Deployment notes

- Pull updated `docker-compose.yml` and run `docker compose up -d` to register the new network aliases
- Once Aam-Digital/ndb-core#3705 is merged and a new image is published, the app container will use the correct defaults automatically

Closes #85