### PR TITLE
fix(swag-proxy): override nginx DNS resolver to fix random 504s on /login

### DIFF
--- a/swag-proxy/aam-dev/config/nginx/proxy-confs/keycloak.dev.subdomain.conf
+++ b/swag-proxy/aam-dev/config/nginx/proxy-confs/keycloak.dev.subdomain.conf
@@ -16,6 +16,14 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    # Includes are placed at server scope (not inside the location) so that
+    # timeout overrides in the location block do not collide with the values
+    # set in proxy.conf — nginx treats redeclaring the same directive in the
+    # same context as a duplicate ("proxy_connect_timeout directive is
+    # duplicate").
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+
     gzip on;
     gzip_types text/plain application/x-javascript text/xml text/css;
     gzip_min_length 1000;
@@ -23,8 +31,6 @@ server {
     gzip_vary on;
 
     location / {
-        include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf;
         set $upstream_app i-keycloak-dev-keycloak-1;
         set $upstream_port 8080;
         set $upstream_proto http;

--- a/swag-proxy/aam-dev/config/nginx/proxy-confs/keycloak.dev.subdomain.conf
+++ b/swag-proxy/aam-dev/config/nginx/proxy-confs/keycloak.dev.subdomain.conf
@@ -30,6 +30,14 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        # Override the long defaults from proxy.conf for this interactive
+        # endpoint so a stalled upstream or DNS hiccup fails fast (visible
+        # error the user can retry) instead of hanging up to 240s and
+        # surfacing as a 504.
+        proxy_connect_timeout 5s;
+        proxy_send_timeout    30s;
+        proxy_read_timeout    30s;
+
         proxy_hide_header Access-Control-Allow-Origin;
         add_header 'Access-Control-Allow-Origin' $allow_origin_keycloak_dev always;
     }

--- a/swag-proxy/aam-dev/config/nginx/resolver.conf
+++ b/swag-proxy/aam-dev/config/nginx/resolver.conf
@@ -1,0 +1,21 @@
+# Override of SWAG's default resolver.conf.
+#
+# Keycloak / replication-backend / API upstreams use the SWAG dynamic-upstream
+# pattern (`set $upstream_app …; proxy_pass http://$upstream_app:…`), which
+# forces nginx to re-resolve the container hostname on every request via
+# Docker's embedded DNS at 127.0.0.11.
+#
+# Under bursty load, Docker's embedded DNS occasionally returns responses with
+# a mismatched transaction ID ("wrong ident NNNN in DNS response …, expect …"),
+# which nginx discards. With the default `resolver_timeout 30s` and `valid=…`
+# unset, this causes random multi-second to multi-minute upstream stalls,
+# producing intermittent 504 Gateway Timeout responses on interactive endpoints
+# such as Keycloak's /login.
+#
+# - `valid=10s`  cache successful lookups for 10s (cuts query rate).
+# - `ipv6=off`   skip parallel AAAA lookups (one of the main triggers of the
+#                ident-mismatch bug in Docker's embedded DNS).
+# - `resolver_timeout 5s`  fail fast so users see a quick error and can retry,
+#                instead of hanging until proxy_read_timeout.
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;

--- a/swag-proxy/aam-dev/docker-compose.yml
+++ b/swag-proxy/aam-dev/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ./config/nginx/proxy-confs/prometheus.subdomain.conf:/config/nginx/proxy-confs/prometheus.subdomain.conf
       - ./config/nginx/proxy-confs/cadvisor.subdomain.conf:/config/nginx/proxy-confs/cadvisor.subdomain.conf
       - ./config/nginx/proxy.conf:/config/nginx/proxy.conf
+      - ./config/nginx/resolver.conf:/config/nginx/resolver.conf
       - /var/docker/volumes/swag-proxy/etc:/config/etc
       - /var/docker/volumes/swag-proxy/fail2ban:/config/fail2ban
       - /var/docker/volumes/swag-proxy/keys:/config/keys

--- a/swag-proxy/aam-prod-2/config/nginx/resolver.conf
+++ b/swag-proxy/aam-prod-2/config/nginx/resolver.conf
@@ -1,0 +1,21 @@
+# Override of SWAG's default resolver.conf.
+#
+# Keycloak / replication-backend / API upstreams use the SWAG dynamic-upstream
+# pattern (`set $upstream_app …; proxy_pass http://$upstream_app:…`), which
+# forces nginx to re-resolve the container hostname on every request via
+# Docker's embedded DNS at 127.0.0.11.
+#
+# Under bursty load, Docker's embedded DNS occasionally returns responses with
+# a mismatched transaction ID ("wrong ident NNNN in DNS response …, expect …"),
+# which nginx discards. With the default `resolver_timeout 30s` and `valid=…`
+# unset, this causes random multi-second to multi-minute upstream stalls,
+# producing intermittent 504 Gateway Timeout responses on interactive endpoints
+# such as Keycloak's /login.
+#
+# - `valid=10s`  cache successful lookups for 10s (cuts query rate).
+# - `ipv6=off`   skip parallel AAAA lookups (one of the main triggers of the
+#                ident-mismatch bug in Docker's embedded DNS).
+# - `resolver_timeout 5s`  fail fast so users see a quick error and can retry,
+#                instead of hanging until proxy_read_timeout.
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;

--- a/swag-proxy/aam-prod-2/docker-compose.yml
+++ b/swag-proxy/aam-prod-2/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - ./config/nginx/proxy-confs/instance.app.subdomain.conf:/config/nginx/proxy-confs/instance.app.subdomain.conf
       - ./config/nginx/proxy-confs/instance.com.subdomain.conf:/config/nginx/proxy-confs/instance.com.subdomain.conf
       - ./config/nginx/proxy.conf:/config/nginx/proxy.conf
+      - ./config/nginx/resolver.conf:/config/nginx/resolver.conf
       - /var/docker/volumes/swag-proxy/etc:/config/etc
       - /var/docker/volumes/swag-proxy/fail2ban:/config/fail2ban
       - /var/docker/volumes/swag-proxy/keys:/config/keys

--- a/swag-proxy/aam-prod-3/config/nginx/proxy-confs/keycloak.prod.subdomain.conf
+++ b/swag-proxy/aam-prod-3/config/nginx/proxy-confs/keycloak.prod.subdomain.conf
@@ -18,6 +18,14 @@ server {
 
     include /config/nginx/ssl.conf;
 
+    # Includes are placed at server scope (not inside the location) so that
+    # timeout overrides in the location block do not collide with the values
+    # set in proxy.conf — nginx treats redeclaring the same directive in the
+    # same context as a duplicate ("proxy_connect_timeout directive is
+    # duplicate").
+    include /config/nginx/proxy.conf;
+    include /config/nginx/resolver.conf;
+
     gzip on;
     gzip_types text/plain application/x-javascript text/xml text/css;
     gzip_min_length 1000;
@@ -25,8 +33,6 @@ server {
     gzip_vary on;
 
     location / {
-        include /config/nginx/proxy.conf;
-        include /config/nginx/resolver.conf;
         set $upstream_app i-keycloak-prod-keycloak-1;
         set $upstream_port 8080;
         set $upstream_proto http;

--- a/swag-proxy/aam-prod-3/config/nginx/proxy-confs/keycloak.prod.subdomain.conf
+++ b/swag-proxy/aam-prod-3/config/nginx/proxy-confs/keycloak.prod.subdomain.conf
@@ -32,6 +32,14 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
+        # Override the long defaults from proxy.conf for this interactive
+        # endpoint so a stalled upstream or DNS hiccup fails fast (visible
+        # error the user can retry) instead of hanging up to 240s and
+        # surfacing as a 504.
+        proxy_connect_timeout 5s;
+        proxy_send_timeout    30s;
+        proxy_read_timeout    30s;
+
         proxy_hide_header Access-Control-Allow-Origin;
         add_header 'Access-Control-Allow-Origin' $allow_origin_keycloak_prod always;
     }

--- a/swag-proxy/aam-prod-3/config/nginx/resolver.conf
+++ b/swag-proxy/aam-prod-3/config/nginx/resolver.conf
@@ -1,0 +1,21 @@
+# Override of SWAG's default resolver.conf.
+#
+# Keycloak / replication-backend / API upstreams use the SWAG dynamic-upstream
+# pattern (`set $upstream_app …; proxy_pass http://$upstream_app:…`), which
+# forces nginx to re-resolve the container hostname on every request via
+# Docker's embedded DNS at 127.0.0.11.
+#
+# Under bursty load, Docker's embedded DNS occasionally returns responses with
+# a mismatched transaction ID ("wrong ident NNNN in DNS response …, expect …"),
+# which nginx discards. With the default `resolver_timeout 30s` and `valid=…`
+# unset, this causes random multi-second to multi-minute upstream stalls,
+# producing intermittent 504 Gateway Timeout responses on interactive endpoints
+# such as Keycloak's /login.
+#
+# - `valid=10s`  cache successful lookups for 10s (cuts query rate).
+# - `ipv6=off`   skip parallel AAAA lookups (one of the main triggers of the
+#                ident-mismatch bug in Docker's embedded DNS).
+# - `resolver_timeout 5s`  fail fast so users see a quick error and can retry,
+#                instead of hanging until proxy_read_timeout.
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;

--- a/swag-proxy/aam-prod-3/docker-compose.yml
+++ b/swag-proxy/aam-prod-3/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - ./config/nginx/proxy-confs/instance.com.subdomain.conf:/config/nginx/proxy-confs/instance.com.subdomain.conf
       - ./config/nginx/site-confs/static.net.aam-digital.conf:/config/nginx/site-confs/static.net.aam-digital.conf
       - ./config/nginx/proxy.conf:/config/nginx/proxy.conf
+      - ./config/nginx/resolver.conf:/config/nginx/resolver.conf
       - /var/docker/volumes/swag-proxy/etc:/config/etc
       - /var/docker/volumes/swag-proxy/fail2ban:/config/fail2ban
       - /var/docker/volumes/swag-proxy/keys:/config/keys

--- a/swag-proxy/aam-prod-4/config/nginx/resolver.conf
+++ b/swag-proxy/aam-prod-4/config/nginx/resolver.conf
@@ -1,0 +1,21 @@
+# Override of SWAG's default resolver.conf.
+#
+# Keycloak / replication-backend / API upstreams use the SWAG dynamic-upstream
+# pattern (`set $upstream_app …; proxy_pass http://$upstream_app:…`), which
+# forces nginx to re-resolve the container hostname on every request via
+# Docker's embedded DNS at 127.0.0.11.
+#
+# Under bursty load, Docker's embedded DNS occasionally returns responses with
+# a mismatched transaction ID ("wrong ident NNNN in DNS response …, expect …"),
+# which nginx discards. With the default `resolver_timeout 30s` and `valid=…`
+# unset, this causes random multi-second to multi-minute upstream stalls,
+# producing intermittent 504 Gateway Timeout responses on interactive endpoints
+# such as Keycloak's /login.
+#
+# - `valid=10s`  cache successful lookups for 10s (cuts query rate).
+# - `ipv6=off`   skip parallel AAAA lookups (one of the main triggers of the
+#                ident-mismatch bug in Docker's embedded DNS).
+# - `resolver_timeout 5s`  fail fast so users see a quick error and can retry,
+#                instead of hanging until proxy_read_timeout.
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;

--- a/swag-proxy/aam-prod-4/docker-compose.yml
+++ b/swag-proxy/aam-prod-4/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ./config/nginx/proxy-confs/instance.app.subdomain.conf:/config/nginx/proxy-confs/instance.app.subdomain.conf
       - ./config/nginx/proxy-confs/instance.com.subdomain.conf:/config/nginx/proxy-confs/instance.com.subdomain.conf
       - ./config/nginx/proxy.conf:/config/nginx/proxy.conf
+      - ./config/nginx/resolver.conf:/config/nginx/resolver.conf
       - /var/docker/volumes/swag-proxy/etc:/config/etc
       - /var/docker/volumes/swag-proxy/fail2ban:/config/fail2ban
       - /var/docker/volumes/swag-proxy/keys:/config/keys


### PR DESCRIPTION
- see https://github.com/Aam-Digital/ndb-core/issues/3916


## Problem

Frontend logins randomly fail with `504 Gateway Timeout` from `/login?redirect_uri=…` (Keycloak). The 504s are intermittent and span several instances/subdomains.

Investigation on `aam-prod-3` ruled out Keycloak and Postgres: container has 0 restarts since 2026‑05‑01, no `ERROR` / `JDBCException` / GC / timeout entries in Keycloak logs, no checkpoint/autovacuum/deadlock/FATAL in Postgres, and `pg_stat_activity` shows no long-running queries.

The smoking gun is in nginx's error log on `swag-proxy-aam-prod-3`:

```
2026/05/05 07:12:06 [error] 896#896: wrong ident 41058 in DNS response
   for socialshapesfoundation-db-entrypoint, expect 55041
```

## Root cause

The keycloak / api / replication-backend vhosts use SWAG's dynamic-upstream pattern:

```nginx
set $upstream_app i-keycloak-prod-keycloak-1;
proxy_pass $upstream_proto://$upstream_app:$upstream_port;
```

Because `$upstream_app` is a variable, **nginx re-resolves the container hostname on every request** via Docker's embedded DNS at `127.0.0.11`. Under bursty load that DNS occasionally returns responses with mismatched transaction IDs (the "wrong ident" log), which nginx discards. With the default `resolver_timeout 30s` and unset `valid=…`, those requests can stretch all the way to `proxy_read_timeout` (240s) before failing — surfacing to the user as random 504s. The login endpoint is the most visible victim because it is interactive and not auto-retried.

## Changes

1. **New `resolver.conf` mounted into all four swag-proxy stacks** (`aam-dev`, `aam-prod-2`, `aam-prod-3`, `aam-prod-4`):

   ```nginx
   resolver 127.0.0.11 valid=10s ipv6=off;
   resolver_timeout 5s;
   ```

   - `valid=10s` caches successful lookups, cutting query rate.
   - `ipv6=off` avoids parallel AAAA lookups (a known trigger of the ident-mismatch bug in Docker's embedded DNS).
   - `resolver_timeout 5s` makes failures surface quickly instead of stretching to 240s.

2. **Tighter timeouts on the keycloak prod vhost** so a stalled login fails fast (visible error the user can retry) instead of hanging:

   ```nginx
   proxy_connect_timeout 5s;
   proxy_send_timeout    30s;
   proxy_read_timeout    30s;
   ```

## Deployment

For each stack, after pulling on the host:

```bash
cd swag-proxy/aam-prod-3   # repeat for the other three stacks
docker compose up -d
```

This recreates the swag-proxy container with the new mount. No data loss, no impact on Keycloak/Postgres/CouchDB.

## Verification after deploy

```bash
# 1. ident-mismatch errors should stop appearing in:
docker exec swag-proxy-aam-prod-3-swag-proxy-1 \
  tail -f /config/log/nginx/error.log

# 2. resolver values are picked up:
docker exec swag-proxy-aam-prod-3-swag-proxy-1 \
  nginx -T 2>/dev/null | grep -E "resolver|resolver_timeout"

# 3. quick latency probe:
docker exec swag-proxy-aam-prod-3-swag-proxy-1 \
  sh -c "time wget -qO- --timeout=5 \
   http://i-keycloak-prod-keycloak-1:8080/realms/master/.well-known/openid-configuration >/dev/null"
```

If 504s persist, we can additionally switch the keycloak vhost to a static `upstream {}` block (resolved once at nginx start), but that requires `nginx -s reload` after Keycloak container IP changes, so it's intentionally not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized DNS resolver configuration across all environments to improve response times and enable faster failure detection, reducing latency in upstream name resolution.
  * Enhanced upstream proxy connection timeout settings to improve service reliability and enable more graceful failure handling during connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->