### PR TITLE
Enable notifications by default with backend; load Firebase config from BWS

### DIFF
--- a/scripts/enable-backend.sh
+++ b/scripts/enable-backend.sh
@@ -36,6 +36,23 @@ fi
 bws config server-base https://vault.bitwarden.eu
 
 ##############################
+# parse flags
+##############################
+
+# --skip-restart: do not restart docker at the end; the caller (e.g. interactive-setup.sh) is responsible
+# for bringing the stack up once, after all enable-* scripts have written their config. Run standalone
+# (without the flag) the script restarts itself. Flags are stripped here so positional args stay intact.
+skipRestart=false
+positionalArgs=()
+for arg in "$@"; do
+  case "$arg" in
+    --skip-restart) skipRestart=true ;;
+    *) positionalArgs+=("$arg") ;;
+  esac
+done
+set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
+
+##############################
 # ask for input data
 ##############################
 
@@ -149,6 +166,8 @@ setEnv REPLICATION_BACKEND_KEYCLOAK_CLIENT_SECRET "$clientSecret" "$path/.env"
 
 setEnv COMPOSE_PROFILES "full-stack" "$path/.env"
 
-(cd "$path" && docker compose up -d)
+if [ "$skipRestart" != "true" ]; then
+  (cd "$path" && docker compose up -d)
+fi
 
 echo "Backend enabled."

--- a/scripts/enable-backend.sh
+++ b/scripts/enable-backend.sh
@@ -117,7 +117,7 @@ mkdir -p "$path/config/aam-backend-service"
 curl -L -o "$path/config/aam-backend-service/application.env" "https://raw.githubusercontent.com/Aam-Digital/aam-services/refs/tags/aam-backend-service/$backendVersion/templates/aam-backend-service/application.template.env"
 
 setEnv CRYPTO_CONFIGURATION_SECRET "$(generate_password)" "$path/config/aam-backend-service/application.env"
-setEnv SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI "https://keycloak.aam-digital.com/realms/$instance" "$path/config/aam-backend-service/application.env"
+setEnv SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI "https://$KEYCLOAK_HOST/realms/$instance" "$path/config/aam-backend-service/application.env"
 setEnv SPRING_DATASOURCE_USERNAME "$(getVar "$path/.env" COUCHDB_USER)" "$path/config/aam-backend-service/application.env"
 setEnv SPRING_DATASOURCE_PASSWORD "$(getVar "$path/.env" COUCHDB_PASSWORD)" "$path/config/aam-backend-service/application.env"
 

--- a/scripts/enable-feature-notification-email.sh
+++ b/scripts/enable-feature-notification-email.sh
@@ -17,6 +17,23 @@ source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 
 ##############################
+# parse flags
+##############################
+
+# --skip-restart: do not restart docker at the end; the caller is responsible for bringing the stack up once
+# after all config is written (e.g. enable-feature-notification.sh, which restarts once for both steps, or
+# interactive-setup.sh). Run standalone the script restarts itself. Flags are stripped so positional args stay intact.
+skipRestart=false
+positionalArgs=()
+for arg in "$@"; do
+  case "$arg" in
+    --skip-restart) skipRestart=true ;;
+    *) positionalArgs+=("$arg") ;;
+  esac
+done
+set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
+
+##############################
 # ask for input data
 ##############################
 
@@ -263,7 +280,10 @@ upsertEnv "KEYCLOAK_CLIENTSECRET" "$keycloakClientSecret" "$appEnv"
 # Restart only at the very end, once all env writes have succeeded. Combined with `set -euo pipefail`,
 # a failure during the file I/O above aborts before this line, so the instance is never taken down with
 # a partially written application.env — it keeps running on its previous, working config.
-(cd "$path" && docker compose down && docker compose up -d)
+# Skipped with --skip-restart when a caller restarts the stack itself after this step.
+if [ "$skipRestart" != "true" ]; then
+  (cd "$path" && docker compose down && docker compose up -d)
+fi
 
 if [ "$keycloakRolesEnsured" == "true" ]; then
   echo "Email notifications enabled."

--- a/scripts/enable-feature-notification.sh
+++ b/scripts/enable-feature-notification.sh
@@ -118,6 +118,11 @@ if [ -n "${BWS_ACCESS_TOKEN}" ]; then
   if [[ -z "$firebaseConfigJson" ]]; then
     echo "WARNING: Could not load firebase-config.json from Bitwarden (secret '$BWS_SECRET_FIREBASE_CONFIG_JSON'); leaving existing file in place."
   else
+    if ! printf '%s' "$firebaseConfigJson" | jq empty 2>/dev/null; then
+      echo "ERROR: Retrieved firebase-config.json is not valid JSON. Abort."
+      exit 1
+    fi
+
     backupFile "$path/firebase-config.json"
     printf '%s' "$firebaseConfigJson" > "$path/firebase-config.json"
     echo "  ~ wrote firebase-config.json (frontend web push config)"

--- a/scripts/enable-feature-notification.sh
+++ b/scripts/enable-feature-notification.sh
@@ -17,6 +17,30 @@ baseDirectory="/var/docker"
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 
+# Bitwarden Secrets Manager key names for the shared Firebase project (the same Firebase credentials are used
+# for every instance). Looked up by name via getBwsSecretByKey:
+#   - the frontend web config (firebase-config.json) the browser uses to register for push notifications
+#   - the backend service-account credential (base64) the aam-backend-service uses to send pushes
+BWS_SECRET_FIREBASE_CONFIG_JSON="FIREBASE_CONFIG_JSON"
+BWS_SECRET_FIREBASE_CREDENTIAL_BASE64="FIREBASE_CREDENTIAL_BASE64"
+
+##############################
+# parse flags
+##############################
+
+# --skip-restart: do not restart docker at the end; the caller (e.g. interactive-setup.sh) restarts the stack
+# once after all enable-* scripts have written their config. Run standalone the script restarts itself.
+# Flags are stripped here so positional args stay intact.
+skipRestart=false
+positionalArgs=()
+for arg in "$@"; do
+  case "$arg" in
+    --skip-restart) skipRestart=true ;;
+    *) positionalArgs+=("$arg") ;;
+  esac
+done
+set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
+
 ##############################
 # ask for input data
 ##############################
@@ -33,6 +57,12 @@ fi
 ##############################
 
 path="$baseDirectory/$PREFIX$instance"
+appEnv="$path/config/aam-backend-service/application.env"
+
+# Point bws at the EU vault once up front so the secret lookups below work (no-op when no token is set).
+if [ -n "${BWS_ACCESS_TOKEN}" ]; then
+  bws config server-base https://vault.bitwarden.eu
+fi
 
 ##############################
 # script
@@ -49,34 +79,61 @@ if ! isBackendConfigCreated; then
   exit 1
 fi
 
-isFeatureAlreadyEnabled=$(getVar "$path/config/aam-backend-service/application.env" FEATURES_NOTIFICATIONAPI_ENABLED)
+isFeatureAlreadyEnabled=$(getVar "$appEnv" FEATURES_NOTIFICATIONAPI_ENABLED)
 
 if [ "$isFeatureAlreadyEnabled" == "true" ]; then
   echo "Feature is already enabled for this instance. Abort."
   exit 1
-else
-  echo ""
 fi
 
-(cd "$path" && docker compose down)
-
-backupFile "$path/config/aam-backend-service/application.env"
-
+# Resolve the backend Firebase service-account credential (base64). Prefer an explicit argument (e.g. for
+# offline/testing), otherwise load it from the Bitwarden Secrets Manager. Because the same shared Firebase
+# project is used for every instance, this is non-interactive and works during automated interactive-setup.
 if [ -n "$2" ]; then
   configCredentialBase64="$2"
 else
-  echo "Insert value for NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64:"
-  read -r configCredentialBase64
+  if [[ -z "${BWS_ACCESS_TOKEN}" ]]; then
+    echo "BWS_ACCESS_TOKEN is not set and no credential argument was given. Abort."
+    exit 1
+  fi
+  configCredentialBase64=$(getBwsSecretByKey "$BWS_SECRET_FIREBASE_CREDENTIAL_BASE64")
+  if [[ -z "$configCredentialBase64" ]]; then
+    echo "ERROR: Could not load the Firebase credential from Bitwarden (secret '$BWS_SECRET_FIREBASE_CREDENTIAL_BASE64'). Abort."
+    exit 1
+  fi
 fi
 
-setEnv "NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64" "$configCredentialBase64" "$path/config/aam-backend-service/application.env"
-setEnv "NOTIFICATIONFIREBASECONFIGURATION_LINKBASEURL" "https://$instance.$DOMAIN" "$path/config/aam-backend-service/application.env"
-setEnv "FEATURES_NOTIFICATIONAPI_MODE" "firebase" "$path/config/aam-backend-service/application.env"
-setEnv "FEATURES_NOTIFICATIONAPI_ENABLED" "true" "$path/config/aam-backend-service/application.env"
+backupFile "$appEnv"
 
-(cd "$path" && docker compose up -d)
+setEnv "NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64" "$configCredentialBase64" "$appEnv"
+setEnv "NOTIFICATIONFIREBASECONFIGURATION_LINKBASEURL" "https://$instance.$DOMAIN" "$appEnv"
+setEnv "FEATURES_NOTIFICATIONAPI_MODE" "firebase" "$appEnv"
+setEnv "FEATURES_NOTIFICATIONAPI_ENABLED" "true" "$appEnv"
 
-# Enable email notifications by default
-"$baseDirectory/ndb-setup/scripts/enable-feature-notification-email.sh" "$instance"
+# Write the frontend Firebase web config the browser uses to register for push notifications. Loaded as a
+# single JSON blob from BWS (shared Firebase project) and written to the file docker-compose mounts into the
+# app container (assets/firebase-config.json), replacing the empty template copied during interactive-setup.
+if [ -n "${BWS_ACCESS_TOKEN}" ]; then
+  firebaseConfigJson=$(getBwsSecretByKey "$BWS_SECRET_FIREBASE_CONFIG_JSON")
+  if [[ -z "$firebaseConfigJson" ]]; then
+    echo "WARNING: Could not load firebase-config.json from Bitwarden (secret '$BWS_SECRET_FIREBASE_CONFIG_JSON'); leaving existing file in place."
+  else
+    backupFile "$path/firebase-config.json"
+    printf '%s' "$firebaseConfigJson" > "$path/firebase-config.json"
+    echo "  ~ wrote firebase-config.json (frontend web push config)"
+  fi
+else
+  echo "WARNING: BWS_ACCESS_TOKEN not set; leaving existing firebase-config.json in place."
+fi
+
+# Enable email notifications by default. Always pass --skip-restart: the email step writes its config but does
+# not restart, so the single restart below applies both the notification and email config in one cycle.
+"$baseDirectory/ndb-setup/scripts/enable-feature-notification-email.sh" "$instance" --skip-restart
+
+# Restart once, here, after both this script and the email step have written their config — unless the caller
+# asked to skip it (interactive-setup restarts the stack itself after all enable-* scripts have run).
+if [ "$skipRestart" != "true" ]; then
+  (cd "$path" && docker compose down && docker compose up -d)
+fi
 
 echo "Feature enabled."

--- a/scripts/interactive-setup.sh
+++ b/scripts/interactive-setup.sh
@@ -401,8 +401,13 @@ if [ "$aamBackendService" == 0 ]; then
   fi
 
   if [ "$withAamBackendService" == "y" ] || [ "$withAamBackendService" == "Y" ]; then
-    $baseDirectory/ndb-setup/scripts/enable-backend.sh "$org"
+    $baseDirectory/ndb-setup/scripts/enable-backend.sh "$org" --skip-restart
     aamBackendService=1
+
+    # Enabling the backend also enables (push + email) notifications by default. The enable script loads the
+    # Firebase credentials from BWS, so this runs non-interactively. --skip-restart is passed because this
+    # script restarts the stack once at the very end, after all enable-* scripts have written their config.
+    $baseDirectory/ndb-setup/scripts/enable-feature-notification.sh "$org" --skip-restart
   fi
 fi
 
@@ -451,6 +456,8 @@ if [ "$app" == 0 ]; then
   fi
 fi
 
-(cd "$path" && docker compose up -d)
+# Single restart for the whole instance, after every enable-* script (run with --skip-restart) has written
+# its config. `down && up -d` (not just `up -d`) forces recreation so changed env_file/config is picked up.
+(cd "$path" && docker compose down && docker compose up -d)
 
 echo "DONE app is now available under https://$url"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -140,6 +140,25 @@ backupFile() {
 }
 
 ##############################
+# Bitwarden Secrets Manager helpers
+##############################
+
+# Look up a Bitwarden Secrets Manager secret by its key/name and print its value to stdout.
+# bws's `secret get` only accepts a UUID, so this lists the accessible secrets and filters by key.
+# The key must be unique among the secrets the token can read; if several match, the first wins.
+# Requires: BWS_ACCESS_TOKEN set and `bws config server-base` already pointed at the right vault.
+# Returns: non-zero (and prints nothing) if no secret with that key is found.
+getBwsSecretByKey() {
+  local key="$1"
+  local value
+  value=$(bws secret list -t "$BWS_ACCESS_TOKEN" 2>/dev/null | jq -r --arg k "$key" 'map(select(.key == $k)) | .[0].value // empty')
+  if [[ -z "$value" ]]; then
+    return 1
+  fi
+  printf '%s' "$value"
+}
+
+##############################
 # Docker compose helpers
 ##############################
 


### PR DESCRIPTION
## What

When enabling the aam-backend in `interactive-setup.sh`, also enable (push + email) notifications by default, and source all Firebase config from the Bitwarden Secrets Manager.

## Changes

**Notifications enabled with backend** ([interactive-setup.sh](../blob/fix/enable-notifications-by-default/scripts/interactive-setup.sh))
- After `enable-backend.sh`, runs `enable-feature-notification.sh` (which chains email notifications). Runs non-interactively now that credentials come from BWS.

**Firebase config from BWS** ([enable-feature-notification.sh](../blob/fix/enable-notifications-by-default/scripts/enable-feature-notification.sh))
- Backend service-account credential (`NOTIFICATIONFIREBASECONFIGURATION_CREDENTIALFILEBASE64`) is loaded from BWS (key `FIREBASE_CREDENTIAL_BASE64`) instead of an interactive prompt. The `$2` arg still works as an offline override.
- Frontend `firebase-config.json` (previously copied **empty** and never populated) is fetched as a single JSON blob from BWS (key `FIREBASE_CONFIG_JSON`) and written to the file docker-compose mounts into the app container.
- New `getBwsSecretByKey` helper in `lib/common.sh` looks secrets up by name (`bws secret list` + filter on `.key`), since `bws secret get` only accepts a UUID.

**Explicit docker restarts via `--skip-restart`** (all enable-* scripts)
- Replaces the previous reliance on script call-stack ordering. Each script restarts itself when run standalone; with `--skip-restart` it trusts the caller. `interactive-setup.sh` passes `--skip-restart` to the enable-* scripts and does a single `down && up -d` at the very end, after all config is written. Result: one restart instead of several redundant down/up cycles.

## Notes / follow-ups
- Name-based BWS lookup requires the key to be unique among secrets the token can read; not yet verified end-to-end against the real vault (no `bws`/token in the dev environment).
- Unrelated: `enable-backend.sh` hard-codes `keycloak.aam-digital.com` as the JWT issuer even though Keycloak/Carbone hosts differ between staging and production — flagging, not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup scripts now support a `--skip-restart` flag to defer stack restarts until the end of the setup flow.
  * Notification feature setup is now non-interactive and Bitwarden-driven for automated Firebase configuration.

* **Enhancements**
  * Consolidated restarts into a single recreate cycle during interactive setup to ensure updated environment/config is applied.
  * Backend configuration now uses the Keycloak host for the selected instance when generating OAuth issuer settings.
  * Added safer behavior: aborts early if the notification feature is already enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->