### PR TITLE
chore: repoint sqs image to ghcr.io/aam-digital/sqs-aam

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
 
   # (optional) needed for aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" is set in the `.env` file
   sqs:
-    image: ghcr.io/aam-digital/aam-sqs-linux:latest
+    image: ghcr.io/aam-digital/sqs-aam:latest
     container_name: ${INSTANCE_NAME}-sqs
     networks:
       - internal_aam


### PR DESCRIPTION
## Summary

The SQS (Structured Query Server) image moved out of `aam-cloud-infrastructure` into the dedicated **[Aam-Digital/sqs-aam](https://github.com/Aam-Digital/sqs-aam)** repo (per https://github.com/Aam-Digital/aam-cloud-infrastructure/issues/146). This repoints the `sqs` service from the old `aam-sqs-linux` package to the new `sqs-aam` image.

```diff
- image: ghcr.io/aam-digital/aam-sqs-linux:latest
+ image: ghcr.io/aam-digital/sqs-aam:latest
```

Same image content (SQS 1.12.1, linux/amd64), pure rename — kept the `:latest` tag, so no behaviour change. The package stays private (same as before), so the existing ghcr pull credentials still apply.

Refs https://github.com/Aam-Digital/aam-cloud-infrastructure/issues/146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image for the background processing service to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->