### PR TITLE
feat(scripts): work as standalone, bws optional setup scripts

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,6 +39,9 @@ KEYCLOAK_URL=
 # replication backend will accept jwt tokens for configured realm public key (replication-backend)
 REPLICATION_BACKEND_PUBLIC_KEY=
 
+# Keycloak realm signing key id, written into couchdb.ini for JWT auth (set by setup-keycloak-realm.sh)
+KEYCLOAK_JWT_KID=
+
 # random secret used for token encryption (replication-backend)
 REPLICATION_BACKEND_JWT_SECRET=
 

--- a/.env.template
+++ b/.env.template
@@ -39,7 +39,7 @@ KEYCLOAK_URL=
 # replication backend will accept jwt tokens for configured realm public key (replication-backend)
 REPLICATION_BACKEND_PUBLIC_KEY=
 
-# Keycloak realm signing key id, written into couchdb.ini for JWT auth (set by setup-keycloak-realm.sh)
+# Keycloak realm signing key id, written into couchdb.ini for JWT auth (set by create-keycloak-realm.sh)
 KEYCLOAK_JWT_KID=
 
 # random secret used for token encryption (replication-backend)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Have a look at `interactive_setup.sh` to see which .env files are loaded there.
 The [scripts folder](./scripts/) provides utilities to enable the backend and its specific API modules.
 Check the documentation in the comments at the top of each file for usage instructions.
 
+## Running individual setup steps
+
+`interactive-setup.sh` is an orchestrator built on standalone, idempotent step scripts. Each step (create
+the instance, set up Keycloak, set up CouchDB, create the initial user, …) can also be run on its own — by
+instance name or path — and, apart from the interactive orchestrator itself, without Bitwarden access.
+
+See **[scripts/README.md](./scripts/README.md)** for the architecture, the shared conventions (config
+resolution, name-or-path instance targeting, idempotency) and how to run or extend the scripts.
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,52 @@
 # Aam Digital Setup
+
 This repository describes how to set up everything that is needed to run the [Aam Digital case management system](https://www.aam-digital.com) in production.
 This includes deploying the app, deploying and connecting the database and optionally deploying and connecting the permission backend and keycloak.
 
-*The source code of the actual application, as well as instructions to run it on your local machine during development, can be found in the [Aam-Digital/ndb-core](https://github.com/Aam-Digital/ndb-core) repository.*
+_The source code of the actual application, as well as instructions to run it on your local machine during development, can be found in the [Aam-Digital/ndb-core](https://github.com/Aam-Digital/ndb-core) repository._
 
-(!) copy the example.* files (e.g. setup.example.env) and add your actual variables and config
-
+(!) copy the example.\* files (e.g. setup.example.env) and add your actual variables and config
 
 ## Systems requirements
-The deployment works with minimal requirements. 
+
+The deployment works with minimal requirements.
 All you need is a system that runs [Docker](https://www.docker.com/) and allows to reach endpoints through a public URL.
-For a single instance a server with **2GB RAM**, a **single CPU** and **20GB disc space** is sufficient.
-With more data and/or more deployments more RAM and CPU power might be necessary or the sync could start to become very slow.
+
 The required disc space scales with the amount of data and especially images and attachments that are saved in the application.
 
-A Keycloak server is required for user management and login.
+A **Keycloak server** is required for user management and login.
 See below to run the Keycloak included here in this setup sample.
 
-To monitor the hardware usage [this repo](https://github.com/Aam-Digital/monitoring/blob/main/docker-compose.yml) contains a Prometheus setup.
-This can be connected with [Grafana](https://grafana.com/) to create a system dashboard and trigger alerts on critical performance.
+You may want to integrate with **Sentry** error monitoring,
+**Prometheus** + Grafana for resource monitoring,
+an uptime monitoring solution
+or other tooling.
 
 ## Deploying the application
+
+This setup repository assumes you will create new folders "next to" the ndb-setup folder in its parent folder.
+e.g.
+
+```text
+~/
+  ./ndb-setup/ (setup tools; cloned from this repository)
+    setup.env (copied from setup.example.env to configure some variables)
+    ./scripts/
+      ...
+  ./c-<instance-name>/
+    .env
+    docker-compose.yml
+    config.json
+    ...
+```
+
 The interactive script `interactive_setup.sh` walks you through the process of setting up new applications.
 Running the setup script will create a new folder in the same parent folder, next to the cloned repo. You can use the script multiple times to create new instances.
 
 1. Clone this repository
-2. Set up local environment by copying setup.example.env file and editing the `setup.env` and `keyloak/.env`
+2. Set up local environment by copying setup.example.env file and editing the `setup.env`
 3. Then run the script and follow the questions in the console to generate the required .env and other files:
-   > ./interactive_setup.sh
+   > ./scripts/interactive_setup.sh
 
 The following things can be automatically done
 
@@ -36,21 +55,22 @@ The following things can be automatically done
 3. (optional) connect with a running Keycloak
 4. (optional) migrate users from CouchDB to Keycloak
 
-To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `.env` file to you sentry DSN.
+To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `setup.env` file to you sentry DSN.
 
-## Adjusting the script
+### Adjusting the script
+
 Some things have to be set for the interactive setup script through environment variables.
 Have a look at `interactive_setup.sh` to see which .env files are loaded there.
 
 1. Domain name for the final applications (variable `domain`)
 2. Prefix for created folders (variable `prefix`)
-3. the `.env` file of the keycloak deployment (see section [User management in Keycloak](#user-management-in-keycloak))
 
-## Enabling API Modules
+### Enabling API Modules
+
 The [scripts folder](./scripts/) provides utilities to enable the backend and its specific API modules.
 Check the documentation in the comments at the top of each file for usage instructions.
 
-## Running individual setup steps
+### Running individual setup steps
 
 `interactive-setup.sh` is an orchestrator built on standalone, idempotent step scripts. Each step (create
 the instance, set up Keycloak, set up CouchDB, create the initial user, …) can also be run on its own — by
@@ -59,7 +79,7 @@ instance name or path — and, apart from the interactive orchestrator itself, w
 See **[scripts/README.md](./scripts/README.md)** for the architecture, the shared conventions (config
 resolution, name-or-path instance targeting, idempotency) and how to run or extend the scripts.
 
------
+---
 
 ## Admin CLI (migrations, statistics, CouchDB operations)
 
@@ -88,9 +108,10 @@ Admin operations such as running config migrations, checking for conflicts, and 
 
 See [cli/README.md](https://github.com/Aam-Digital/ndb-core/blob/master/cli/README.md) in the ndb-core repository for the full command reference.
 
+---
 
------
-# Deploying under a domain name using swag-proxy
+## Deploying under a domain name using swag-proxy
+
 In order to make the application's docker container accessible under a public URL, you need to expose it using a tool of your choice.
 The system works well with the [swag-proxy](https://docs.linuxserver.io/general/swag/). This allows to automatically configure things so that the app is reachable under a specific domain name (including automatic setup of SSL certificates through letsencrypt).
 
@@ -98,22 +119,25 @@ This setup repository comes with a [docker compose](https://github.com/Aam-Digit
 
 1. Create the required network
    > docker network create external_web
-2. In `swag-proxy/<server>/docker-compose.yml` set `EMAIL` to a valid email address and adapt the DOMAINS config to match your setup. 
-2. In `swag-proxy/<server>/config/dns-conf/` create a new `hetzner-cloud.ini` file from the example file and add your API token
+2. In `swag-proxy/<server>/docker-compose.yml` set `EMAIL` to a valid email address and adapt the DOMAINS config to match your setup.
+3. In `swag-proxy/<server>/config/dns-conf/` create a new `hetzner-cloud.ini` file from the example file and add your API token
    (required for DNS authentication of certbot when creating new SSL certificates)
-3. Start the required containers (this is only needed once on a server)
-   > cd nginx-proxy && docker-compose up -d  
+4. Start the required containers (this is only needed once on a server)
+   > cd nginx-proxy && docker-compose up -d
 
+---
 
------
-# User management in Keycloak
+## User management in Keycloak
+
 The system uses the [Keycloak](https://www.keycloak.org/) identity management system.
-All the required configuration can be found in the `keycloak` folder.
+You must have a Keycloak server to run in parallel to the Aam Digital system.
+
+If you do not already run a Keycloak, you can use the standard setup in the `keycloak` folder to run it through docker as well.
 
 We use a custom build of Keycloak that includes certain plugins required for 2-Factor-Auth.
-Plugin versions are managed within that custom docker image in [Aam-Digital/aam-cloud-infrastructure](https://github.com/Aam-Digital/aam-cloud-infrastructure).
 
 To start the required docker containers execute the following (this is only needed once on a server, you can skip these steps if you just want to add another Aam Digital instance to an existing keycloak server):
+
 1. Open the file `keycloak/.env`
 2. Set the password variables to secure passwords and assign valid urls for the Keycloak (without `https://`)
 3. Start the required containers
@@ -125,16 +149,20 @@ Once done, applications can be connected with Keycloak through the `interactive_
 You can create a custom realm_config.json in each baseConfig folder to overwrite this.
 
 ## 2-Factor-Auth
+
 Keycloak supports a second login factor through the methods described below:
+
 - Authenticator App
 - E-Mail OTP
 
 ### Authenticator app OTP
+
 The only built-in second factor ist OTP using a Authenticator app.
 This can be enabled by editing a specific user in the Keycloak "Administration Console" and adding the `Configure OTP` in the "Required user actions".
 It can also be activated for everyone by changing the `Browser - Conditional OTP` in the used Browser flow from `Conditional` to `Required`.
 
 ### Email OTP
+
 Through 3rd party libraries OTP via Email is supported.
 This also comes with the option to trust the device for a configured time period (during which you do not have to enter the OTP when logging in).
 
@@ -143,20 +171,23 @@ If you created this realm using a recent version of the `realm_config.json` then
 otherwise see the steps below in the next section ("Setting up Email OTP manually").
 
 #### Activating Email 2FA
+
 To activate 2FA over email, click on the 3 dot menu on the right of the `Email 2FA` flow and select `Bind flow` and select `Browser flow`.
 After saving, when trying to log in to the app you should be asked to enter the OTP which has been sent to the email that is associated with the username.
 
 #### Deactivating Email 2FA
+
 Similar to the steps of activating the 2FA flow, to disable it you need to re-activate the normal "browser" flow:
 Click on the 3 dot menu on the right of the `browser` flow, select `Bind flow` and then select `Browser flow`.
 
 _Disabling 2FA for a specific account can be configured but is not part of default setup yet. Please check with existing sample systems for the setup to make the following instructions work:_
+
 > To disable email 2FA for only one individually user assign the Keycloak User Role "no-email-2fa" to that user account to skip 2FA for that person.
 > If the role does not exist yet, create it in the Keycloak Admin interface.
 > (The logic of this special role is configured within the `Email 2FA` Authentication flow as a condition)
 
-
 #### Setting up Email OTP manually
+
 If the `Email 2FA` flow is not available in the realm (section "Authentication"), you can configure it manually:
 
 1. Click on the 3 dot menu of the `browser` flow and select duplicate
@@ -178,86 +209,94 @@ Now the flow is configured correctly, and you can start using it the same way it
 In the step `Email OTP` you can configure the amount of seconds for which an OTP is valid and in the `Register Trusted Device` step you can configure how long a device will be trusted (e.g. `P30d` for 30 days or `PT24h` for 24 hours).
 
 ### Further options
+
 There are many ways in which the authentication flow can be configured.
 For example, you could also add the trust device step to the OTP with authenticator app, or you could make the user decide which OTP (email or app) should be used.
 Consult the [Keycloak docs](https://www.keycloak.org/docs/latest/server_admin/index.html#_authentication-flows) for ways to edit flows or configure new ones.
 
+---
 
------
-# API Integrations and SQL Reports
+## API Integrations and SQL Reports
+
 It is possible to calculate reports for the app's data using SQL queries.
 For details information, check our [Report documentation](http://aam-digital.github.io/ndb-core/documentation/additional-documentation/how-to-guides/create-a-report.html)
 
-## Set up API Integration
+### Set up API Integration
+
 (e.g. with TolaData)
 
 1. Enable the reporting backend:
-    - add `aam-backend-service` to you COMPOSE_PROFILES .env variable to activate that container in the docker compose: `COMPOSE_PROFILES=replication-backend,aam-backend-service`
-    - add `AAM_BACKEND_SERVICE_URL=http://aam-backend-service:3000` to the .env file that feeds into the docker-compose.yml
+   - add `aam-backend-service` to you COMPOSE_PROFILES .env variable to activate that container in the docker compose: `COMPOSE_PROFILES=replication-backend,aam-backend-service`
+   - add `AAM_BACKEND_SERVICE_URL=http://aam-backend-service:3000` to the .env file that feeds into the docker-compose.yml
 2. Set up Reporting API according to [aam-services README](https://github.com/Aam-Digital/aam-services/blob/main/README.md)
-    - (re-up the docker compose and confirm the new containers are running)
-    - follow instructions there to set up an auth client to access results via API
+   - (re-up the docker compose and confirm the new containers are running)
+   - follow instructions there to set up an auth client to access results via API
 
+---
 
------
-# Backups
+## Backups
+
 Basic backup scripts are available in the "scripts" folder.
 
 Set the setup.env variables for the backup root folder and passphrase (to encrypt backups).
 Then run the `backup.sh` script to create a current backup.
 
 ### Scheduled regular backups
+
 You can set up the script to run via cron:
 
 Start the new cron job
+
 ```bash
 crontab -e
 # then enter the following (adjusted to your actual file locations)
-0 2 * * *       /var/docker/ndb-setup/backup.sh 
-# the above runs every day at 2 am 
+0 2 * * *       /var/docker/ndb-setup/backup.sh
+# the above runs every day at 2 am
 ```
 
 ### Restoring a backup
-Under `/var/docker` run the interactive script `backup-recover.sh` to load a backup for a certain client from a certain date. 
+
+Under `/var/docker` run the interactive script `backup-recover.sh` to load a backup for a certain client from a certain date.
 
 To manually load a backup follow these steps:
+
 1. Find the passphrase in the `/var/docker/backup.sh` file.
 2. Go to `mnt/<backup-volume>/backups`
-3.  Decrypt a backup using
-	```bash
-	gpg --passphrase \<passphrase\> -o output -d \<backup-file\>
-	```
+3. Decrypt a backup using
+   ```bash
+   gpg --passphrase \<passphrase\> -o output -d \<backup-file\>
+   ```
 4. Decompress the backup
-	```bash
-	mkdir ./unpacked && tar -xzvf output --directory ./unpacked
-	```
+   ```bash
+   mkdir ./unpacked && tar -xzvf output --directory ./unpacked
+   ```
 5. Go to application where backups should be applied and stop docker container
-	```bash
-	cd /var/docker/ndb-\<instance\>
-	docker compose down
-	```
+   ```bash
+   cd /var/docker/ndb-\<instance\>
+   docker compose down
+   ```
 6. Load the backup
-	```bash
-	mv couchdb couchdb_old && mv ~/backups/unpacked/var/docker/ndb-\<instance\>/couchdb ./couchdb
-	```
+   ```bash
+   mv couchdb couchdb_old && mv ~/backups/unpacked/var/docker/ndb-\<instance\>/couchdb ./couchdb
+   ```
 7. Start the docker containers
-	```bash
-	docker compose up -d
-	```
+   ```bash
+   docker compose up -d
+   ```
 8. After everything works as expected, delete all temporary data
-	```bash
-	rm -rf couchdb_old ~/backups/output ~/backups/unpacked
-	```
+   ```bash
+   rm -rf couchdb_old ~/backups/output ~/backups/unpacked
+   ```
 
 When applying a backup, do not forget to clear you browser cache before opening the application again. Otherwise the previously corrupted data will be synced from the browser to the DB that has just been backed up. To delete all local data go to `https://<instance>.aam-digital.com/support` and press `Reset Application`. All users, which have corrupted data will need to do this.
 
 More information on CouchDB backups can be found [here](https://docs.couchdb.org/en/latest/maintenance/backups.html).
 
+---
 
+## Building the Docker Image
 
------
-# Building the Docker Image
-*If you just want to use ndb-core through docker, you should not have to build the image yourself. Use the pre-built image on Docker Hub [aamdigital/ndb-server](https://cloud.docker.com/u/aamdigital/repository/docker/aamdigital/ndb-server).*
+_If you just want to use ndb-core through docker, you should not have to build the image yourself. Use the pre-built image on Docker Hub [aamdigital/ndb-server](https://cloud.docker.com/u/aamdigital/repository/docker/aamdigital/ndb-server)._
 
 The Dockerfile to build the image are part of the [ndb-core repository](https://github.com/Aam-Digital/ndb-core).
 See the `/build` sub folder there.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following things can be automatically done
 3. (optional) connect with a running Keycloak
 4. (optional) migrate users from CouchDB to Keycloak
 
-To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `setup.env` file to you sentry DSN.
+To log errors with [Sentry](https://sentry.io/), simply set the variable `SENTRY_DSN` in the `setup.env` file to your Sentry DSN.
 
 ### Adjusting the script
 
@@ -226,7 +226,7 @@ For details information, check our [Report documentation](http://aam-digital.git
 (e.g. with TolaData)
 
 1. Enable the reporting backend:
-   - add `aam-backend-service` to you COMPOSE_PROFILES .env variable to activate that container in the docker compose: `COMPOSE_PROFILES=replication-backend,aam-backend-service`
+   - add `aam-backend-service` to your COMPOSE_PROFILES .env variable to activate that container in the docker compose: `COMPOSE_PROFILES=replication-backend,aam-backend-service`
    - add `AAM_BACKEND_SERVICE_URL=http://aam-backend-service:3000` to the .env file that feeds into the docker-compose.yml
 2. Set up Reporting API according to [aam-services README](https://github.com/Aam-Digital/aam-services/blob/main/README.md)
    - (re-up the docker compose and confirm the new containers are running)
@@ -256,7 +256,7 @@ crontab -e
 
 ### Restoring a backup
 
-Under `/var/docker` run the interactive script `backup-recover.sh` to load a backup for a certain client from a certain date.
+Under `/var/docker` run the interactive script `backup-restore.sh` to load a backup for a certain client from a certain date.
 
 To manually load a backup follow these steps:
 
@@ -288,7 +288,7 @@ To manually load a backup follow these steps:
    rm -rf couchdb_old ~/backups/output ~/backups/unpacked
    ```
 
-When applying a backup, do not forget to clear you browser cache before opening the application again. Otherwise the previously corrupted data will be synced from the browser to the DB that has just been backed up. To delete all local data go to `https://<instance>.aam-digital.com/support` and press `Reset Application`. All users, which have corrupted data will need to do this.
+When applying a backup, do not forget to clear your browser cache before opening the application again. Otherwise the previously corrupted data will be synced from the browser to the DB that has just been backed up. To delete all local data go to `https://<instance>.aam-digital.com/support` and press `Reset Application`. All users, which have corrupted data will need to do this.
 
 More information on CouchDB backups can be found [here](https://docs.couchdb.org/en/latest/maintenance/backups.html).
 

--- a/print-env-for-all-instances.sh
+++ b/print-env-for-all-instances.sh
@@ -1,21 +1,10 @@
 #!/bin/bash
+# Print each instance's COMPOSE_PROFILES (deployment type).
 
-# Funktion zum Abrufen der Umgebungsvariablen
-getVar() {
-    local file="$1"
-    local var="$2"
-
-    # grep sucht die Zeile mit der Variable, cut extrahiert den Wert
-    local value=$(grep "^$var=" "$file" | cut -d '=' -f2-)
-
-    # Falls die Variable nicht existiert oder leer ist, eine Meldung ausgeben
-    if [ -z "$value" ]; then
-        echo "Variable $var nicht gefunden oder leer"
-        return 1
-    fi
-
-    echo "$value"
-}
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+source "$scriptDir/setup.env"
+source "$scriptDir/scripts/lib/common.sh"
 
 getComposeProfiles() {
   local raw_value="$1"
@@ -34,12 +23,13 @@ getComposeProfiles() {
   esac
 }
 
-for D in *; do
-        if [ -d "${D}" ] && [[ $D == c-* ]]; then
-                cd "$D" || exit;
-                instance_name="${D#c-}"
+printInstanceProfiles() {
+  local dir="$1"
+  local instance_name="${dir##*/}"
+  instance_name="${instance_name#"$PREFIX"}"
+  local profiles
+  profiles=$(getVar "$dir/.env" COMPOSE_PROFILES)
+  echo "$instance_name -> $profiles -> $(getComposeProfiles "$profiles")"
+}
 
-                echo "$instance_name -> $(getVar .env COMPOSE_PROFILES) -> $(getComposeProfiles "$(getVar .env COMPOSE_PROFILES)")"
-                cd ..
-        fi
-done
+forEachInstance printInstanceProfiles

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,169 @@
+# ndb-setup scripts
+
+Shell scripts that provision and maintain Aam Digital instances on a server. This document explains how
+they fit together so both **developers** (extending them) and **admins** (running them) can work with
+confidence.
+
+For the higher-level deployment walkthrough, see the [repository README](../README.md); this file focuses
+on the scripts' architecture and shared conventions.
+
+## Directory layout & assumptions
+
+Every script assumes this on-disk layout, where the `ndb-setup` checkout sits next to the instance folders:
+
+```
+<baseDirectory>/
+├── ndb-setup/                 # this repository (the checkout)
+│   ├── setup.env              # server/environment config (sourced by every script)
+│   ├── docker-compose.yml     # template copied into each instance
+│   ├── .env.template          # template copied into each instance
+│   └── scripts/
+│       ├── lib/               # shared helpers (sourced, never run directly)
+│       └── *.sh
+├── c-acme/                    # an instance  ($PREFIX + name)
+│   ├── .env                   # per-instance config — the source of truth for that instance
+│   ├── couchdb.ini
+│   └── ...
+└── c-beta/                    # another instance
+```
+
+`baseDirectory` is the parent of the checkout, `PREFIX` (from `setup.env`, e.g. `c-`) namespaces the
+instance folders, and each instance's `.env` (`INSTANCE_NAME`, `COUCHDB_*`, `COMPOSE_PROFILES`, …) is the
+authoritative record for that instance.
+
+## Architecture
+
+### 1. Orchestrator — `interactive-setup.sh`
+
+The entry point for creating a new instance end to end. It gathers answers (interactively or from
+positional args), then **delegates each step to a standalone script**. It is the only script that
+*requires* Bitwarden (`BWS_ACCESS_TOKEN`); it owns the prompts and the single final restart.
+
+```
+interactive-setup.sh
+  ├─ create-dns-record.sh
+  ├─ create-instance.sh
+  ├─ create-keycloak-realm.sh
+  ├─ create-couchdb.sh
+  ├─ create-initial-user.sh
+  ├─ enable-backend.sh        (optional)
+  └─ enable-sentry.sh
+```
+
+### 2. Standalone step & feature scripts
+
+Each step above is a self-contained script that can also be run on its own — e.g. to re-configure
+Keycloak or recreate the databases for an existing instance. Feature toggles (`enable-backend.sh`,
+`enable-feature-notification.sh`, `enable-feature-notification-email.sh`, `enable-assets-overwrites.sh`)
+and maintenance/migration scripts follow the same conventions.
+
+### 3. Shared library — `lib/`
+
+Sourced by scripts, never executed directly. See [lib reference](#lib-reference) below.
+
+## Shared conventions
+
+Every non-trivial script follows these. When you write a new one, follow them too.
+
+### Standard header (relocatable — no hard-coded paths)
+
+`baseDirectory` is **derived from the script's own location**, never hard-coded, so the checkout can live
+anywhere:
+
+```bash
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout
+source "$baseDirectory/ndb-setup/setup.env"
+source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
+source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"   # if it needs secrets
+```
+
+Root-level scripts (one directory up, in the checkout root) use `baseDirectory="$(cd "$scriptDir/.." && pwd)"`.
+
+### Config & secrets — `getConfig` / `requireConfig`
+
+Scripts never call `bws` directly. They resolve values through [`lib/secrets.sh`](lib/secrets.sh), which
+**hides where a value comes from**:
+
+1. an already-set environment variable / `setup.env` value, else
+2. the Bitwarden Secrets Manager — **only** when `BWS_ACCESS_TOKEN` is set and the key has a known UUID.
+
+```bash
+requireConfig KEYCLOAK_HOST      # aborts with a clear message if unresolved; exports $KEYCLOAK_HOST
+value=$(getConfig SMTP_SERVER)   # returns non-zero if unresolved (caller decides)
+```
+
+**Consequence:** the standalone scripts run **without BWS** — just put the needed values in `setup.env`
+or the environment. Only `interactive-setup.sh` (and the not-yet-converted one-off migrations) require a
+token. To add a new BWS-backed value, add its `NAME → UUID` mapping to `_bwsSecretId` in `lib/secrets.sh`.
+
+### Instance targeting — name **or** path
+
+Scripts that operate on an existing instance accept their `<instance>` argument as either an instance
+**name** (resolved to `$baseDirectory/$PREFIX<name>`) or a **path** to the instance directory, including
+`.` when run from inside the folder. This is handled by `resolveInstancePath` (sets the global `path`);
+the org/realm name is then read from that directory's `.env` (`INSTANCE_NAME`).
+
+```bash
+./create-couchdb.sh acme                 # by name (standard layout)
+./create-couchdb.sh /srv/instances/c-acme  # by explicit path
+cd /srv/instances/c-acme && …/create-couchdb.sh .   # "." from inside the folder
+```
+
+`forEachInstance <callback> [instance]` iterates every instance, or a single one (name or path) when the
+argument is given.
+
+### Idempotency
+
+Scripts are safe to re-run. They preserve existing files and generated secrets (never regenerate a
+CouchDB password or bump a pinned version on re-run — see `ensureRealValue`), skip already-created
+Keycloak realms/clients/users and CouchDB databases, and only send onboarding email on first creation.
+
+### `--skip-restart`
+
+Feature scripts that write config accept `--skip-restart` so an orchestrator can write all config first
+and restart the stack **once** at the end. Run standalone (without the flag) they restart themselves.
+
+## lib reference
+
+| File | Provides |
+| --- | --- |
+| [`common.sh`](lib/common.sh) | `.env` helpers (`getVar`, `setEnv`, `upsertEnv`, `ensureEnv`, `ensureRealValue`, `removeEnv`), `generate_password`, `backupFile`, instance resolution (`resolveInstancePath`, `forEachInstance`), state checks (`backendEnabledCheck`, `replicationBackendEnabledCheck`), `getLatestBackendVersion`, docker-compose volume-mount helpers |
+| [`secrets.sh`](lib/secrets.sh) | `getConfig` / `requireConfig` and the `NAME → BWS UUID` map (`_bwsSecretId`) |
+| [`couchdb.sh`](lib/couchdb.sh) | `couchdbInitStart` / `couchdbCurl` / `couchdbInitStop` — bring up the database-only CouchDB init container, run authenticated requests, tear it down |
+| [`keycloak.sh`](lib/keycloak.sh) | `getKeycloakToken`, `getKeycloakRealmKey`, `createKeycloakBackendClient`, `serviceAccountHasRealmManagementRole` |
+
+Each script documents its own arguments and purpose in a header comment — run `head -n 20 <script>.sh` or
+open the file. Rather than duplicate that here, note only the deviations from the conventions above:
+
+- **One-off migrations** (`migrate-*.sh`) have their `baseDirectory` derived but still load secrets
+  directly from BWS; they are kept as historical one-offs, not converted to `getConfig`.
+- **`backup.sh` / `backup-restore.sh`** still target `/var/docker` for the actual backup data path (the
+  tar and restore paths are coupled), so they are not relocatable for the backup operation itself.
+- **`collect-credentials.sh`** is intentionally self-contained (meant to be copied out; takes an
+  `INSTANCES_DIR` arg, default `/var/docker`) and does not source `lib/`.
+- **`enable-feature-notification.sh`** still needs BWS for a *fresh* Firebase config (Firebase is JSON,
+  not a scalar `getConfig` can resolve).
+
+## Running without Bitwarden
+
+Provide the values the script needs in `setup.env` or the environment (see
+[`setup.example.env`](../setup.example.env)); then any converted script runs without a token:
+
+```bash
+KEYCLOAK_HOST=keycloak.example.com KEYCLOAK_USER=admin KEYCLOAK_PASSWORD=… \
+  ./create-keycloak-realm.sh /srv/instances/c-acme en
+```
+
+If a required value is missing, `requireConfig` prints exactly which one and how to supply it.
+
+## Adding a new script
+
+1. Start from the [standard header](#standard-header-relocatable--no-hard-coded-paths); source only the
+   lib files you use.
+2. Take the instance as `$1`; resolve it with `resolveInstancePath` and read the org from
+   `getVar "$path/.env" INSTANCE_NAME` (or accept a name for creation-time scripts).
+3. Resolve any secret with `requireConfig NAME` (add its UUID to `lib/secrets.sh` if BWS-backed).
+4. Make every effect idempotent (guard creates, use `ensureRealValue` for generated values).
+5. If it writes config for a running stack, support `--skip-restart`.
+6. Document its arguments and purpose in a header comment (the single source of truth for per-script docs).

--- a/scripts/backend-config-migration.sh
+++ b/scripts/backend-config-migration.sh
@@ -15,7 +15,8 @@
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 
@@ -24,17 +25,14 @@ source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 ##############################
 
 if [ -n "$1" ]; then
-  instance="$1"
+  instanceArg="$1"
 else
-  echo "What is the name of the instance?"
-  read -r instance
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
 fi
-
-##############################
-# variables
-##############################
-
-path="$baseDirectory/$PREFIX$instance"
+resolveInstancePath "$instanceArg" || exit 1
+instance=$(getVar "$path/.env" INSTANCE_NAME)
+[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
 
 
 ##############################

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -2,7 +2,8 @@
 
 # simple script for importing a backup to an instance
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 backupRoot=$BACKUP_DIR
 passphrase=$BACKUP_PASSPHRASE

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -30,8 +30,8 @@ fi
 
 echo "For which instance do you want to import the backup?"
 read -r org
-folder=c-$org
-cd /var/docker/$folder
+folder="${PREFIX}$org"
+cd "$baseDirectory/$folder"
 docker compose down
 mv couchdb couchdb_tmp
 mv "$unpackDir/var/docker/$folder/couchdb" ./couchdb

--- a/scripts/backup-restore.sh
+++ b/scripts/backup-restore.sh
@@ -31,10 +31,13 @@ fi
 echo "For which instance do you want to import the backup?"
 read -r org
 folder="${PREFIX}$org"
-cd "$baseDirectory/$folder"
+cd "$baseDirectory/$folder" || exit 1
 docker compose down
 mv couchdb couchdb_tmp
-mv "$unpackDir/var/docker/$folder/couchdb" ./couchdb
+# backup.sh archives "$baseDirectory" with tar, which strips the leading "/" from the stored paths,
+# so the unpacked tree is rooted at $baseDirectory without its leading slash (not necessarily "var/docker")
+archiveRoot="${baseDirectory#/}"
+mv "$unpackDir/$archiveRoot/$folder/couchdb" ./couchdb
 docker compose up -d
 echo "backup restored for $folder and instance has been restarted"
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -12,7 +12,7 @@ passphrase=$BACKUP_PASSPHRASE
 targetFile=$backupRoot/`date +%Y%m%d`
 echo "Creating backup $targetFile ($(date '+%Y-%m-%d %H:%M:%S')) ..."
 
-tar zcf $targetFile.tar.gz /var/docker
+tar zcf "$targetFile.tar.gz" "$baseDirectory"
 gpg -c --batch --passphrase "$passphrase" $targetFile.tar.gz
 chown root:root $targetFile.tar.gz.gpg
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -3,7 +3,8 @@
 # simple script to create encrypted backups
 # can be scheduled via cron
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 backupRoot=$BACKUP_DIR
 passphrase=$BACKUP_PASSPHRASE

--- a/scripts/create-couchdb.sh
+++ b/scripts/create-couchdb.sh
@@ -92,7 +92,7 @@ echo "  ~ wrote JWT signing key into couchdb.ini"
 ##############################
 
 echo "Starting CouchDB for '$org'..."
-couchdbInitStart
+couchdbInitStart || exit 1
 
 # create the required databases (201 = created, 412 = already exists; anything else is a real failure)
 for db in _users app report-calculation notification-webhook app-attachments; do

--- a/scripts/create-couchdb.sh
+++ b/scripts/create-couchdb.sh
@@ -94,9 +94,13 @@ echo "  ~ wrote JWT signing key into couchdb.ini"
 echo "Starting CouchDB for '$org'..."
 couchdbInitStart
 
-# create the required databases (PUT is a no-op / 412 for already-existing databases)
+# create the required databases (201 = created, 412 = already exists; anything else is a real failure)
 for db in _users app report-calculation notification-webhook app-attachments; do
-  couchdbCurl -X PUT "$DB_LOCAL_URL/$db" >/dev/null
+  status=$(couchdbCurl -X PUT "$DB_LOCAL_URL/$db" -o /dev/null -w "%{http_code}")
+  if [ "$status" != "201" ] && [ "$status" != "412" ]; then
+    echo "ERROR: failed to create database '$db' (HTTP $status). Abort."
+    exit 1
+  fi
   echo "  ensured database '$db'"
 done
 

--- a/scripts/create-couchdb.sh
+++ b/scripts/create-couchdb.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Configure CouchDB for an instance: write the JWT signing key into couchdb.ini, start the database,
+# create the required databases and (for a directly-exposed database-only instance) apply document-level
+# security so only JWTs with the "user_app" role can access the data.
+# Idempotent: couchdb.ini is regenerated from the template each run, database creation tolerates existing
+# databases, and _security is (re)applied. Reads everything it needs from the instance .env — no secrets.
+#
+# Usage:
+#   ./create-couchdb.sh <instance> [--with-permissions]
+#
+# <instance>           an instance name (standard $baseDirectory/$PREFIX<name> layout) OR a path to the
+#                      instance directory (e.g. "." when run from inside it, or /any/path/to/instance)
+# --with-permissions   the replication-backend enforces access, so CouchDB stays internal and the
+#                      user_app document security is NOT applied. Omit it for a database-only instance
+#                      (CouchDB exposed directly) where the user_app _security must be applied.
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+source "$scriptDir/lib/couchdb.sh"
+
+##############################
+# parse flags
+##############################
+
+withPermissions=false
+positionalArgs=()
+for arg in "$@"; do
+  case "$arg" in
+    --with-permissions) withPermissions=true ;;
+    *) positionalArgs+=("$arg") ;;
+  esac
+done
+set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  instanceArg="$1"
+else
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
+fi
+resolveInstancePath "$instanceArg" || exit 1
+if [ ! -d "$path" ]; then
+  echo "ERROR: instance directory not found: $path (run create-instance.sh first). Abort."
+  exit 1
+fi
+org=$(getVar "$path/.env" INSTANCE_NAME)
+
+couchDbUser=$(getVar "$path/.env" COUCHDB_USER)
+couchDbPassword=$(getVar "$path/.env" COUCHDB_PASSWORD)
+kid=$(getVar "$path/.env" KEYCLOAK_JWT_KID)
+publicKey=$(getVar "$path/.env" REPLICATION_BACKEND_PUBLIC_KEY)
+
+if [ -z "$couchDbUser" ] || [ -z "$couchDbPassword" ]; then
+  echo "ERROR: COUCHDB_USER / COUCHDB_PASSWORD missing in $path/.env. Abort."
+  exit 1
+fi
+if [ -z "$kid" ] || [ -z "$publicKey" ]; then
+  echo "ERROR: KEYCLOAK_JWT_KID / REPLICATION_BACKEND_PUBLIC_KEY missing in $path/.env."
+  echo "  Run create-keycloak-realm.sh first. Abort."
+  exit 1
+fi
+
+##############################
+# couchdb.ini (JWT signing key)
+##############################
+
+# Regenerate from the pristine template each run (the template is static apart from the key placeholders),
+# which keeps the substitution idempotent and update-safe even if the key rotated.
+cp "$ndbSetupDir/couchdb.ini" "$path/couchdb.ini"
+# '|' delimiter avoids clashing with '/' in a base64 key; escape sed-special chars in the value
+escapedKey=$(printf '%s' "$publicKey" | sed 's/[\\&|]/\\&/g')
+sed -i "s|<KID>|$kid|g" "$path/couchdb.ini"
+sed -i "s|<PUBLIC_KEY>|$escapedKey|g" "$path/couchdb.ini"
+echo "  ~ wrote JWT signing key into couchdb.ini"
+
+##############################
+# start database + create databases
+##############################
+
+echo "Starting CouchDB for '$org'..."
+couchdbInitStart
+
+# create the required databases (PUT is a no-op / 412 for already-existing databases)
+for db in _users app report-calculation notification-webhook app-attachments; do
+  couchdbCurl -X PUT "$DB_LOCAL_URL/$db" >/dev/null
+  echo "  ensured database '$db'"
+done
+
+# For a database-only instance CouchDB is exposed directly, so restrict app / app-attachments to the
+# "user_app" role. With the replication-backend (--with-permissions) CouchDB is internal and the backend
+# enforces access, so this security is intentionally skipped.
+if [ "$withPermissions" = false ]; then
+  echo "Applying document-level security (user_app role)..."
+  couchdbCurl -X PUT "$DB_LOCAL_URL/app/_security" \
+    -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }' >/dev/null
+  couchdbCurl -X PUT "$DB_LOCAL_URL/app-attachments/_security" \
+    -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }' >/dev/null
+fi
+
+# Remove the temporary init container so a later profile switch can reuse the -db-entrypoint name.
+# Data in ./couchdb/data is preserved. Bring the instance up afterwards with `docker compose up -d`.
+couchdbInitStop
+
+echo "CouchDB configured for '$org'."

--- a/scripts/create-dns-record.sh
+++ b/scripts/create-dns-record.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Create the DNS CNAME record for an instance (Hetzner DNS).
+# Idempotent: if a CNAME with the instance name already exists in the zone, it is left untouched.
+#
+# Usage:
+#   ./create-dns-record.sh <instance>
+#
+# Config (via setup.env / environment, or Bitwarden Secrets Manager when BWS_ACCESS_TOKEN is set):
+#   DNS_HETZNER_API_TOKEN, DNS_HETZNER_ZONE_ID_APP   (BWS-backed)
+#   DNS_SERVER_NAME                                  (setup.env / environment)
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  org="$1"
+else
+  echo "What is the name of the organisation?"
+  read -r org
+fi
+# keycloak realms are case sensitive elsewhere, so keep the name lowercase everywhere
+org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
+
+requireConfig DNS_HETZNER_API_TOKEN
+requireConfig DNS_HETZNER_ZONE_ID_APP
+requireConfig DNS_SERVER_NAME
+
+##############################
+# script
+##############################
+
+# idempotency: skip if a CNAME with this name already exists in the zone
+existingId=$(curl -s "https://dns.hetzner.com/api/v1/records?zone_id=$DNS_HETZNER_ZONE_ID_APP" \
+  -H "Auth-API-Token: $DNS_HETZNER_API_TOKEN" \
+  | jq -r --arg n "$org" '.records[]? | select(.type=="CNAME" and .name==$n) | .id' | head -n1)
+
+if [ -n "$existingId" ]; then
+  echo "DNS record for '$org' already exists (id $existingId), skipping."
+  exit 0
+fi
+
+echo "Creating DNS CNAME record for '$org'..."
+curl -X "POST" "https://dns.hetzner.com/api/v1/records" \
+     -H 'Content-Type: application/json' \
+     -H "Auth-API-Token: $DNS_HETZNER_API_TOKEN" \
+     -d "{
+  \"value\": \"$DNS_SERVER_NAME.aam-digital.net.\",
+  \"type\": \"CNAME\",
+  \"name\": \"$org\",
+  \"zone_id\": \"$DNS_HETZNER_ZONE_ID_APP\"
+}"
+echo

--- a/scripts/create-dns-record.sh
+++ b/scripts/create-dns-record.sh
@@ -54,13 +54,19 @@ if [ -n "$existingId" ]; then
 fi
 
 echo "Creating DNS CNAME record for '$org'..."
-curl -X "POST" "https://dns.hetzner.com/api/v1/records" \
+body=$(jq -n \
+  --arg value "$DNS_SERVER_NAME.aam-digital.net." \
+  --arg name "$org" \
+  --arg zone_id "$DNS_HETZNER_ZONE_ID_APP" \
+  '{value: $value, type: "CNAME", name: $name, zone_id: $zone_id}')
+
+status=$(curl -s -o /dev/null -w "%{http_code}" -X "POST" "https://dns.hetzner.com/api/v1/records" \
      -H 'Content-Type: application/json' \
      -H "Auth-API-Token: $DNS_HETZNER_API_TOKEN" \
-     -d "{
-  \"value\": \"$DNS_SERVER_NAME.aam-digital.net.\",
-  \"type\": \"CNAME\",
-  \"name\": \"$org\",
-  \"zone_id\": \"$DNS_HETZNER_ZONE_ID_APP\"
-}"
-echo
+     -d "$body")
+
+if [ "$status" != "200" ] && [ "$status" != "201" ]; then
+  echo "ERROR: failed to create DNS record for '$org' (HTTP $status)." >&2
+  exit 1
+fi
+echo "DNS record created."

--- a/scripts/create-initial-user.sh
+++ b/scripts/create-initial-user.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# Create the initial admin user for an instance, in Keycloak (with all realm roles, email 2FA, and a
+# verification email) and as a User document in CouchDB.
+# Idempotent: an existing Keycloak user or CouchDB document is reused; the verification email is only
+# sent when the Keycloak user is newly created, so re-running never re-sends onboarding mail.
+#
+# Usage:
+#   ./create-initial-user.sh <instance> <email> <name>
+#
+# <instance>  an instance name (standard $baseDirectory/$PREFIX<name> layout) OR a path to the instance
+#             directory (e.g. "." when run from inside it). The realm name is read from the .env INSTANCE_NAME.
+#
+# Config (via setup.env / environment, or Bitwarden Secrets Manager when BWS_ACCESS_TOKEN is set):
+#   KEYCLOAK_HOST, KEYCLOAK_USER, KEYCLOAK_PASSWORD
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+source "$scriptDir/lib/keycloak.sh"
+source "$scriptDir/lib/couchdb.sh"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  instanceArg="$1"
+else
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
+fi
+resolveInstancePath "$instanceArg" || exit 1
+if [ ! -d "$path" ]; then
+  echo "ERROR: instance directory not found: $path (run create-instance.sh first). Abort."
+  exit 1
+fi
+org=$(getVar "$path/.env" INSTANCE_NAME)
+if [ -z "$org" ]; then
+  echo "ERROR: INSTANCE_NAME not set in $path/.env. Abort."
+  exit 1
+fi
+
+if [ -n "$2" ]; then
+  userEmail="$2"
+else
+  echo "Email address of initial user"
+  read -r userEmail
+fi
+if [ -n "$3" ]; then
+  userName="$3"
+else
+  echo "Name of initial user"
+  read -r userName
+fi
+if [ -z "$userEmail" ] || [ -z "$userName" ]; then
+  echo "ERROR: both email and name are required. Abort."
+  exit 1
+fi
+
+requireConfig KEYCLOAK_HOST
+requireConfig KEYCLOAK_USER
+requireConfig KEYCLOAK_PASSWORD
+
+##############################
+# Keycloak user
+##############################
+
+if ! getKeycloakToken; then
+  echo "ERROR: could not authenticate against Keycloak. Abort."
+  exit 1
+fi
+
+userId=$(curl -s -H "Authorization: Bearer $token" \
+  "https://$KEYCLOAK_HOST/admin/realms/$org/users?username=$userName&exact=true" | jq -r '.[0].id // empty')
+
+userCreated=false
+if [ -n "$userId" ]; then
+  echo "Keycloak user '$userName' already exists ($userId), reusing."
+else
+  echo "Creating Keycloak user '$userName'..."
+  curl -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
+    -d "{\"username\": \"$userName\",\"enabled\": true,\"email\": \"$userEmail\",\"attributes\": {\"exact_username\": \"User:$userName\"},\"emailVerified\": false,\"credentials\": [], \"requiredActions\": [\"UPDATE_PASSWORD\", \"VERIFY_EMAIL\"]}" \
+    "https://$KEYCLOAK_HOST/admin/realms/$org/users"
+  userId=$(curl -s -H "Authorization: Bearer $token" \
+    "https://$KEYCLOAK_HOST/admin/realms/$org/users?username=$userName&exact=true" | jq -r '.[0].id // empty')
+  userCreated=true
+fi
+
+if [ -z "$userId" ]; then
+  echo "ERROR: could not resolve Keycloak user id for '$userName'. Abort."
+  exit 1
+fi
+echo "User id $userId"
+
+# assign all realm roles (idempotent — Keycloak ignores already-assigned roles)
+roles=$(curl -s -H "Authorization: Bearer $token" "https://$KEYCLOAK_HOST/admin/realms/$org/roles")
+echo "assign realm roles..."
+curl -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d "$roles" \
+  "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/role-mappings/realm" >/dev/null
+
+# enable email 2FA by removing the "no-email-2fa" role (idempotent — removing an absent mapping is harmless)
+echo "enable 2fa for user..."
+roleId=$(curl -s -X GET "https://$KEYCLOAK_HOST/admin/realms/$org/roles" -H "Authorization: Bearer $token" \
+  | jq -r '.[] | select(.name=="no-email-2fa") | .id')
+if [ -z "$roleId" ]; then
+  echo "  WARNING: no 'no-email-2fa' role found."
+else
+  curl -s -X DELETE "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/role-mappings/realm" \
+    -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
+    -d "[{\"id\": \"$roleId\"}]" >/dev/null
+fi
+
+# send the verification email only for a freshly-created user, so re-runs do not re-send onboarding mail
+if [ "$userCreated" = true ]; then
+  echo "send verification email..."
+  # no redirect_uri: Keycloak falls back to the "app" client's baseUrl for the "back to application" link
+  curl -s -X PUT -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d '["VERIFY_EMAIL"]' \
+    "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/execute-actions-email?client_id=app" >/dev/null
+fi
+
+##############################
+# CouchDB user document
+##############################
+
+echo "ensure user document in CouchDB..."
+couchdbInitStart
+if [ "$(couchdbCurl -o /dev/null -w '%{http_code}' "$DB_LOCAL_URL/app/User:$userName")" = "200" ]; then
+  echo "  = User:$userName document already exists, keeping it"
+else
+  couchdbCurl -X PUT -H 'Content-Type: application/json' -d "{\"name\": \"$userName\"}" \
+    "$DB_LOCAL_URL/app/User:$userName" >/dev/null
+  echo "  + created User:$userName document"
+fi
+couchdbInitStop
+
+echo "Initial user '$userName' is set up for '$org'."

--- a/scripts/create-initial-user.sh
+++ b/scripts/create-initial-user.sh
@@ -79,19 +79,23 @@ if ! getKeycloakToken; then
   exit 1
 fi
 
-userId=$(curl -s -H "Authorization: Bearer $token" \
-  "https://$KEYCLOAK_HOST/admin/realms/$org/users?username=$userName&exact=true" | jq -r '.[0].id // empty')
+userId=$(curl -s -G -H "Authorization: Bearer $token" \
+  --data-urlencode "username=$userName" --data-urlencode "exact=true" \
+  "https://$KEYCLOAK_HOST/admin/realms/$org/users" | jq -r '.[0].id // empty')
 
 userCreated=false
 if [ -n "$userId" ]; then
   echo "Keycloak user '$userName' already exists ($userId), reusing."
 else
   echo "Creating Keycloak user '$userName'..."
+  newUserPayload=$(jq -n --arg username "$userName" --arg email "$userEmail" --arg exactUsername "User:$userName" \
+    '{username: $username, enabled: true, email: $email, attributes: {exact_username: [$exactUsername]}, emailVerified: false, credentials: [], requiredActions: ["UPDATE_PASSWORD", "VERIFY_EMAIL"]}')
   curl -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' \
-    -d "{\"username\": \"$userName\",\"enabled\": true,\"email\": \"$userEmail\",\"attributes\": {\"exact_username\": \"User:$userName\"},\"emailVerified\": false,\"credentials\": [], \"requiredActions\": [\"UPDATE_PASSWORD\", \"VERIFY_EMAIL\"]}" \
+    -d "$newUserPayload" \
     "https://$KEYCLOAK_HOST/admin/realms/$org/users"
-  userId=$(curl -s -H "Authorization: Bearer $token" \
-    "https://$KEYCLOAK_HOST/admin/realms/$org/users?username=$userName&exact=true" | jq -r '.[0].id // empty')
+  userId=$(curl -s -G -H "Authorization: Bearer $token" \
+    --data-urlencode "username=$userName" --data-urlencode "exact=true" \
+    "https://$KEYCLOAK_HOST/admin/realms/$org/users" | jq -r '.[0].id // empty')
   userCreated=true
 fi
 
@@ -131,14 +135,18 @@ fi
 # CouchDB user document
 ##############################
 
+userDocId="User:$userName"
+encodedUserDocId=$(jq -rn --arg v "$userDocId" '$v|@uri')
+
 echo "ensure user document in CouchDB..."
 couchdbInitStart
-if [ "$(couchdbCurl -o /dev/null -w '%{http_code}' "$DB_LOCAL_URL/app/User:$userName")" = "200" ]; then
-  echo "  = User:$userName document already exists, keeping it"
+if [ "$(couchdbCurl -o /dev/null -w '%{http_code}' "$DB_LOCAL_URL/app/$encodedUserDocId")" = "200" ]; then
+  echo "  = $userDocId document already exists, keeping it"
 else
-  couchdbCurl -X PUT -H 'Content-Type: application/json' -d "{\"name\": \"$userName\"}" \
-    "$DB_LOCAL_URL/app/User:$userName" >/dev/null
-  echo "  + created User:$userName document"
+  userDocPayload=$(jq -n --arg name "$userName" '{name: $name}')
+  couchdbCurl -X PUT -H 'Content-Type: application/json' -d "$userDocPayload" \
+    "$DB_LOCAL_URL/app/$encodedUserDocId" >/dev/null
+  echo "  + created $userDocId document"
 fi
 couchdbInitStop
 

--- a/scripts/create-initial-user.sh
+++ b/scripts/create-initial-user.sh
@@ -139,7 +139,7 @@ userDocId="User:$userName"
 encodedUserDocId=$(jq -rn --arg v "$userDocId" '$v|@uri')
 
 echo "ensure user document in CouchDB..."
-couchdbInitStart
+couchdbInitStart || exit 1
 if [ "$(couchdbCurl -o /dev/null -w '%{http_code}' "$DB_LOCAL_URL/app/$encodedUserDocId")" = "200" ]; then
   echo "  = $userDocId document already exists, keeping it"
 else

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Create the instance directory and its base configuration (.env, couchdb.ini, docker-compose.yml, ...)
+# and apply the selected baseConfig overlay. Does NOT touch Keycloak or start any container.
+# Idempotent: existing files are never overwritten and generated secrets / versions are written only once,
+# so re-running never regenerates the CouchDB password or bumps versions of an existing instance.
+#
+# Usage:
+#   ./create-instance.sh <instance> [baseConfig]
+#
+# No secrets required. Reads DOMAIN / PREFIX from setup.env.
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  org="$1"
+else
+  echo "What is the name of the organisation?"
+  read -r org
+fi
+# keycloak realms are case sensitive elsewhere, so keep the name lowercase everywhere
+org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
+
+if grep -Fxq "$org" "$scriptDir/blacklist.txt"; then
+  echo "Error: The organisation name '$org' is blacklisted. Please try another one."
+  exit 1
+fi
+if [ ${#org} -ge 24 ]; then
+  echo "Error: The organisation name must have less than 24 letters. Please try a shorter one."
+  exit 1
+fi
+
+# baseConfig (optional)
+if [ -n "$2" ]; then
+  baseConfig="$2"
+else
+  echo "Which basic config do you want to include? (e.g. [default], basic, codo, ...)"
+  read -r baseConfig
+  [ -n "$baseConfig" ] || baseConfig=default
+fi
+if [ ! -d "$ndbSetupDir/baseConfigs/$baseConfig" ]; then
+  echo "ERROR Invalid base config '$baseConfig'. Abort."
+  exit 1
+fi
+
+path="$baseDirectory/$PREFIX$org"
+url=$org.$DOMAIN
+
+##############################
+# instance directory + template files
+##############################
+
+echo "Setting up instance directory for '$org' at $path"
+mkdir -p "$path"
+mkdir -p "$path/couchdb/data"
+
+# copy template files, but never overwrite an existing (possibly customized) file
+for f in .env couchdb.ini config.json docker-compose.yml firebase-config.json; do
+  if [ ! -f "$path/$f" ]; then
+    cp "$ndbSetupDir/$f" "$path/$f"
+    echo "  + copied $f"
+  else
+    echo "  = $f already exists, keeping it"
+  fi
+done
+
+##############################
+# base .env values
+##############################
+
+# deterministic identity values (safe to (re)write)
+setEnv INSTANCE_NAME "$org" "$path/.env"
+setEnv INSTANCE_DOMAIN "$DOMAIN" "$path/.env"
+
+# write-once values: keep whatever an existing instance already has (see ensureRealValue)
+ensureRealValue COUCHDB_USER "aam-admin" "$path/.env"
+ensureRealValue COUCHDB_PASSWORD "$(generate_password)" "$path/.env"
+ensureRealValue REPLICATION_BACKEND_JWT_SECRET "$(generate_password)" "$path/.env"
+ensureRealValue COMPOSE_PROFILES "database-only" "$path/.env"
+
+# versions: pin to the latest available release once; keep an existing instance's pinned versions
+ensureRealValue APP_VERSION \
+  "$(curl -s https://api.github.com/repos/Aam-Digital/ndb-core/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')" \
+  "$path/.env"
+ensureRealValue AAM_REPLICATION_BACKEND_VERSION \
+  "$(curl -s https://api.github.com/repos/Aam-Digital/replication-backend/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')" \
+  "$path/.env"
+ensureRealValue AAM_BACKEND_SERVICE_VERSION "$(getLatestBackendVersion)" "$path/.env"
+
+##############################
+# baseConfig overlay
+##############################
+
+# to add config or other docs to CouchDB, mount them to the assets/base-configs folder of ndb-core
+# and use an `available-configs.json` entry to make it selectable in the app
+# see https://github.com/Aam-Digital/ndb-core/blob/master/src/assets/base-configs/available-configs.json
+if [ -d "$ndbSetupDir/baseConfigs/$baseConfig/assets" ]; then
+  "$scriptDir/enable-assets-overwrites.sh" "$org" "$baseConfig"
+fi
+
+# Apply a config overlay shipped by the baseConfig. The baseConfig's `config/` folder mirrors the
+# instance `config/` tree 1:1 and is copied verbatim, so e.g. a custom notification email template at
+# `config/aam-backend-service/templates/notification/create-notification-email-template.html` lands at
+# the path docker-compose mounts into the aam-backend-service container (/opt/app/templates).
+# Note: this only adds files (e.g. templates/); the per-instance application.env is generated later by
+# enable-backend.sh, so the two never collide.
+if [ -d "$ndbSetupDir/baseConfigs/$baseConfig/config" ]; then
+  echo "Applying config overlay from baseConfig '$baseConfig'..."
+  mkdir -p "$path/config"
+  cp -r "$ndbSetupDir/baseConfigs/$baseConfig/config/." "$path/config/"
+fi
+
+echo "Instance '$org' prepared. App URL: https://$url"

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -69,7 +69,7 @@ mkdir -p "$path"
 mkdir -p "$path/couchdb/data"
 
 # copy template files, but never overwrite an existing (possibly customized) file
-for f in .env couchdb.ini config.json docker-compose.yml firebase-config.json; do
+for f in couchdb.ini config.json docker-compose.yml firebase-config.json; do
   if [ ! -f "$path/$f" ]; then
     cp "$ndbSetupDir/$f" "$path/$f"
     echo "  + copied $f"
@@ -78,13 +78,21 @@ for f in .env couchdb.ini config.json docker-compose.yml firebase-config.json; d
   fi
 done
 
+# the instance .env is generated from .env.template (note the different source name)
+if [ ! -f "$path/.env" ]; then
+  cp "$ndbSetupDir/.env.template" "$path/.env"
+  echo "  + copied .env (from .env.template)"
+else
+  echo "  = .env already exists, keeping it"
+fi
+
 ##############################
 # base .env values
 ##############################
 
-# deterministic identity values (safe to (re)write)
-setEnv INSTANCE_NAME "$org" "$path/.env"
-setEnv INSTANCE_DOMAIN "$DOMAIN" "$path/.env"
+# deterministic identity values (upsert so they are written even into a partial .env)
+upsertEnv INSTANCE_NAME "$org" "$path/.env"
+upsertEnv INSTANCE_DOMAIN "$DOMAIN" "$path/.env"
 
 # write-once values: keep whatever an existing instance already has (see ensureRealValue)
 ensureRealValue COUCHDB_USER "aam-admin" "$path/.env"

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -35,6 +35,10 @@ fi
 # keycloak realms are case sensitive elsewhere, so keep the name lowercase everywhere
 org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
 
+if ! isValidOrgName "$org"; then
+  echo "Error: The organisation name must be non-empty and contain only lowercase letters, digits, and hyphens (not starting/ending with a hyphen). Please try another one."
+  exit 1
+fi
 if grep -Fxq "$org" "$scriptDir/blacklist.txt"; then
   echo "Error: The organisation name '$org' is blacklisted. Please try another one."
   exit 1
@@ -100,14 +104,38 @@ ensureRealValue COUCHDB_PASSWORD "$(generate_password)" "$path/.env"
 ensureRealValue REPLICATION_BACKEND_JWT_SECRET "$(generate_password)" "$path/.env"
 ensureRealValue COMPOSE_PROFILES "database-only" "$path/.env"
 
-# versions: pin to the latest available release once; keep an existing instance's pinned versions
-ensureRealValue APP_VERSION \
-  "$(curl -s https://api.github.com/repos/Aam-Digital/ndb-core/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')" \
-  "$path/.env"
-ensureRealValue AAM_REPLICATION_BACKEND_VERSION \
-  "$(curl -s https://api.github.com/repos/Aam-Digital/replication-backend/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')" \
-  "$path/.env"
-ensureRealValue AAM_BACKEND_SERVICE_VERSION "$(getLatestBackendVersion)" "$path/.env"
+# versions: pin to the latest available release once; keep an existing instance's pinned versions.
+# Only hit the network when a real version isn't already pinned, and abort rather than persist an
+# empty/null version if the lookup fails (a rerun on an already-pinned instance never depends on this).
+appVersion=""
+if isPlaceholderValue "$(getVar "$path/.env" APP_VERSION)"; then
+  appVersion=$(curl -fsSL https://api.github.com/repos/Aam-Digital/ndb-core/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')
+  if [ -z "$appVersion" ] || [ "$appVersion" = "null" ]; then
+    echo "ERROR: could not determine latest ndb-core release version. Abort."
+    exit 1
+  fi
+fi
+ensureRealValue APP_VERSION "$appVersion" "$path/.env"
+
+replicationBackendVersion=""
+if isPlaceholderValue "$(getVar "$path/.env" AAM_REPLICATION_BACKEND_VERSION)"; then
+  replicationBackendVersion=$(curl -fsSL https://api.github.com/repos/Aam-Digital/replication-backend/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')
+  if [ -z "$replicationBackendVersion" ] || [ "$replicationBackendVersion" = "null" ]; then
+    echo "ERROR: could not determine latest replication-backend release version. Abort."
+    exit 1
+  fi
+fi
+ensureRealValue AAM_REPLICATION_BACKEND_VERSION "$replicationBackendVersion" "$path/.env"
+
+backendVersion=""
+if isPlaceholderValue "$(getVar "$path/.env" AAM_BACKEND_SERVICE_VERSION)"; then
+  backendVersion=$(getLatestBackendVersion)
+  if [ -z "$backendVersion" ] || [ "$backendVersion" = "null" ]; then
+    echo "ERROR: could not determine latest aam-backend-service release version. Abort."
+    exit 1
+  fi
+fi
+ensureRealValue AAM_BACKEND_SERVICE_VERSION "$backendVersion" "$path/.env"
 
 ##############################
 # baseConfig overlay
@@ -129,7 +157,7 @@ fi
 if [ -d "$ndbSetupDir/baseConfigs/$baseConfig/config" ]; then
   echo "Applying config overlay from baseConfig '$baseConfig'..."
   mkdir -p "$path/config"
-  cp -r "$ndbSetupDir/baseConfigs/$baseConfig/config/." "$path/config/"
+  cp -Rn "$ndbSetupDir/baseConfigs/$baseConfig/config/." "$path/config/"
 fi
 
 echo "Instance '$org' prepared. App URL: https://$url"

--- a/scripts/create-keycloak-realm.sh
+++ b/scripts/create-keycloak-realm.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# Create (or reuse) the Keycloak realm and the "app" client for an instance, download keycloak.json,
+# and persist the realm's signing key into the instance .env for CouchDB / replication-backend JWT auth.
+# Idempotent: an existing realm or client is reused; keycloak.json and the key values are (re)written each run.
+#
+# Usage:
+#   ./create-keycloak-realm.sh <instance> [locale] [baseConfig]
+#
+# <instance>  an instance name (standard $baseDirectory/$PREFIX<name> layout) OR a path to the instance
+#             directory (e.g. "." when run from inside it). The realm name is read from the .env INSTANCE_NAME.
+#
+# Config (via setup.env / environment, or Bitwarden Secrets Manager when BWS_ACCESS_TOKEN is set):
+#   KEYCLOAK_HOST, KEYCLOAK_USER, KEYCLOAK_PASSWORD, SMTP_SERVER, SMTP_PASSWORD
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+source "$scriptDir/lib/keycloak.sh"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  instanceArg="$1"
+else
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
+fi
+resolveInstancePath "$instanceArg" || exit 1
+if [ ! -d "$path" ]; then
+  echo "ERROR: instance directory not found: $path (run create-instance.sh first). Abort."
+  exit 1
+fi
+org=$(getVar "$path/.env" INSTANCE_NAME)
+if [ -z "$org" ]; then
+  echo "ERROR: INSTANCE_NAME not set in $path/.env. Abort."
+  exit 1
+fi
+url=$org.$DOMAIN
+
+if [ -n "$2" ]; then
+  locale="$2"
+else
+  echo "Which should be the default language for Keycloak ('en', 'de', ...)?"
+  read -r locale
+fi
+
+baseConfig="${3:-}"
+
+requireConfig KEYCLOAK_HOST
+requireConfig KEYCLOAK_USER
+requireConfig KEYCLOAK_PASSWORD
+requireConfig SMTP_SERVER
+requireConfig SMTP_PASSWORD
+
+##############################
+# script
+##############################
+
+setEnv KEYCLOAK_URL "$KEYCLOAK_HOST" "$path/.env"
+
+if ! getKeycloakToken; then
+  echo "ERROR: could not authenticate against Keycloak. Abort."
+  exit 1
+fi
+
+# create the realm (idempotent: skip if it already exists)
+realmStatus=$(curl -s -o /dev/null -w "%{http_code}" -L "https://$KEYCLOAK_HOST/admin/realms/$org" \
+  -H "Authorization: Bearer $token")
+if [ "$realmStatus" = "200" ]; then
+  echo "Keycloak realm '$org' already exists, skipping creation."
+else
+  echo "Creating Keycloak realm '$org'..."
+  # take the custom baseConfig realm file or otherwise the default from keycloak folder
+  keycloakRealmFile="$ndbSetupDir/keycloak/realm_config.json"
+  if [ -n "$baseConfig" ] && [ -f "$ndbSetupDir/baseConfigs/$baseConfig/realm_config.json" ]; then
+    keycloakRealmFile="$ndbSetupDir/baseConfigs/$baseConfig/realm_config.json"
+  fi
+  # add and replace some customized values
+  keycloakRealmJson=$(jq \
+    --arg realm "$org" \
+    --arg locale "$locale" \
+    --arg host "$SMTP_SERVER" \
+    --arg password "$SMTP_PASSWORD" \
+    '.realm = $realm
+     | .defaultLocale = $locale
+     | .displayName = "Aam Digital - " + $realm
+     | .smtpServer.from = "accounts@aam-digital.com"
+     | .smtpServer.host = $host
+     | .smtpServer.port = "587"
+     | .smtpServer.user = "accounts@aam-digital.com"
+     | .smtpServer.password = $password' \
+    "$keycloakRealmFile")
+
+  curl -X "POST" "https://$KEYCLOAK_HOST/admin/realms" \
+       -H "Authorization: Bearer $token" \
+       -H "Content-Type: application/json" \
+       -d "$keycloakRealmJson"
+fi
+
+# create the "app" client (idempotent: reuse existing)
+client=$(curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$org/clients?clientId=app" \
+  -H "Authorization: Bearer $token" | jq -r '.[0].id // empty')
+if [ -n "$client" ]; then
+  echo "Keycloak 'app' client already exists ($client), skipping creation."
+else
+  echo "Creating Keycloak 'app' client..."
+  clientResponse=$(curl -s -D - -o /dev/null -X POST "https://$KEYCLOAK_HOST/admin/realms/$org/clients" \
+    -H "Authorization: Bearer $token" \
+    -H "Content-Type: application/json" \
+    -d "$(jq '.baseUrl = "https://'"$url"'"' "$ndbSetupDir/keycloak/client_config.json")")
+  location=$(echo "$clientResponse" | grep -i "^location:")
+  client=$(echo "$location" | sed -n 's#.*\([a-f0-9]\{8\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{12\}\).*#\1#p')
+  if [ -z "$client" ]; then
+    echo "ERROR: failed to create Keycloak 'app' client. Abort."
+    exit 1
+  fi
+fi
+
+# download the app's keycloak.json (frontend adapter config)
+curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$org/clients/$client/installation/providers/keycloak-oidc-keycloak-json" \
+  -H "Authorization: Bearer $token" > "$path/keycloak.json"
+
+# persist the realm signing key so create-couchdb.sh can configure JWT auth without any Keycloak access
+if ! getKeycloakRealmKey "$org"; then
+  echo "ERROR: could not read realm signing key. Abort."
+  exit 1
+fi
+upsertEnv REPLICATION_BACKEND_PUBLIC_KEY "$publicKey" "$path/.env"
+upsertEnv KEYCLOAK_JWT_KID "$kid" "$path/.env"
+
+echo "Keycloak realm '$org' is configured."

--- a/scripts/create-keycloak-realm.sh
+++ b/scripts/create-keycloak-realm.sh
@@ -118,7 +118,7 @@ else
   clientResponse=$(curl -s -D - -o /dev/null -X POST "https://$KEYCLOAK_HOST/admin/realms/$org/clients" \
     -H "Authorization: Bearer $token" \
     -H "Content-Type: application/json" \
-    -d "$(jq '.baseUrl = "https://'"$url"'"' "$ndbSetupDir/keycloak/client_config.json")")
+    -d "$(jq --arg url "https://$url" '.baseUrl = $url' "$ndbSetupDir/keycloak/client_config.json")")
   location=$(echo "$clientResponse" | grep -i "^location:")
   client=$(echo "$location" | sed -n 's#.*\([a-f0-9]\{8\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{12\}\).*#\1#p')
   if [ -z "$client" ]; then
@@ -128,8 +128,11 @@ else
 fi
 
 # download the app's keycloak.json (frontend adapter config)
-curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$org/clients/$client/installation/providers/keycloak-oidc-keycloak-json" \
-  -H "Authorization: Bearer $token" > "$path/keycloak.json"
+if ! curl -s -f -L "https://$KEYCLOAK_HOST/admin/realms/$org/clients/$client/installation/providers/keycloak-oidc-keycloak-json" \
+  -H "Authorization: Bearer $token" > "$path/keycloak.json"; then
+  echo "ERROR: failed to download keycloak.json. Abort."
+  exit 1
+fi
 
 # persist the realm signing key so create-couchdb.sh can configure JWT auth without any Keycloak access
 if ! getKeycloakRealmKey "$org"; then

--- a/scripts/enable-assets-overwrites.sh
+++ b/scripts/enable-assets-overwrites.sh
@@ -11,7 +11,8 @@
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 

--- a/scripts/enable-assets-overwrites.sh
+++ b/scripts/enable-assets-overwrites.sh
@@ -13,8 +13,10 @@
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
-source "$baseDirectory/ndb-setup/setup.env"
-source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
 
 ##############################
 # ask for input data
@@ -46,7 +48,7 @@ else
 fi
 
 # abort if no assets folder for baseConfig exists
-baseConfigPath="$baseDirectory/ndb-setup/baseConfigs/$baseConfig"
+baseConfigPath="$ndbSetupDir/baseConfigs/$baseConfig"
 if [ ! -d "$baseConfigPath/assets" ]; then
   echo "No assets folder found for baseConfig '$baseConfig'. Abort."
   exit 1

--- a/scripts/enable-backend.sh
+++ b/scripts/enable-backend.sh
@@ -26,10 +26,12 @@
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
-source "$baseDirectory/ndb-setup/setup.env"
-source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
-source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
-source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+source "$scriptDir/lib/keycloak.sh"
 
 ##############################
 # parse flags
@@ -60,7 +62,10 @@ else
 fi
 resolveInstancePath "$instanceArg" || exit 1
 instance=$(getVar "$path/.env" INSTANCE_NAME)
-[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
+if [ -z "$instance" ]; then
+  instance="$(basename "$path")"
+  instance="${instance#"$PREFIX"}"
+fi
 
 ##############################
 # variables

--- a/scripts/enable-backend.sh
+++ b/scripts/enable-backend.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
 # This script will enable the backend for an customer instance.
-# All needed credentials are loaded/stored from/to the Bitwarden Secrets Manager
+# Credentials are resolved via getConfig: from setup.env / the environment, falling back to the
+# Bitwarden Secrets Manager when BWS_ACCESS_TOKEN is set (so it can run without BWS access).
 
 # how to use
 #
 # make sure to install the dependencies: ./install-dependencies.sh
 #
-# ./enable-backend.sh <instance> (optional) <password>
+# ./enable-backend.sh <instance>
 # example: ./enable-backend.sh qm
+#   <instance>  an instance name (standard $baseDirectory/$PREFIX<name> layout) OR a path to the
+#               instance directory (e.g. "." when run from inside it)
 #
 # Requires: CARBONE_HOST set in setup.env (environment-specific):
 #   Environment  KEYCLOAK_HOST                  CARBONE_HOST
@@ -21,19 +24,12 @@
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
+source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
 source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"
-
-# check if BWS_ACCESS_TOKEN is set
-if [[ -z "${BWS_ACCESS_TOKEN}" ]]; then
-  echo "BWS_ACCESS_TOKEN is not set. Abort."
-  exit 1
-fi
-
-# set server-base to EU instance
-bws config server-base https://vault.bitwarden.eu
 
 ##############################
 # parse flags
@@ -57,26 +53,27 @@ set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
 ##############################
 
 if [ -n "$1" ]; then
-  instance="$1"
+  instanceArg="$1"
 else
-  echo "What is the name of the instance?"
-  read -r instance
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
 fi
+resolveInstancePath "$instanceArg" || exit 1
+instance=$(getVar "$path/.env" INSTANCE_NAME)
+[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
 
 ##############################
 # variables
 ##############################
 
-path="$baseDirectory/$PREFIX$instance"
-
-# load secrets from Bitwarden Secret Manager
-RENDER_API_CLIENT_ID_DEV=$(bws secret -t "$BWS_ACCESS_TOKEN" get "b53d7a1d-220e-4e07-b1f9-b22700711f79" | jq -r .value)
-RENDER_API_CLIENT_SECRET_DEV=$(bws secret -t "$BWS_ACCESS_TOKEN" get "83a8e38b-fc22-461f-91a0-b22700712b62" | jq -r .value)
-SENTRY_AUTH_TOKEN=$(bws secret -t "$BWS_ACCESS_TOKEN" get "b9a3e1eb-3925-4ed6-93f4-b2270073c82c" | jq -r .value)
-SENTRY_DSN_BACKEND=$(bws secret -t "$BWS_ACCESS_TOKEN" get "a858a580-9643-4330-8667-b2270073d7a6" | jq -r .value)
-KEYCLOAK_HOST=$(bws secret -t "$BWS_ACCESS_TOKEN" get "3db87144-76c9-4690-8f59-b22600c8c927" | jq -r .value)
-KEYCLOAK_PASSWORD=$(bws secret -t "$BWS_ACCESS_TOKEN" get "c5f42f09-b1c8-43a8-ae75-b22600c8f2e5" | jq -r .value)
-KEYCLOAK_USER=$(bws secret -t "$BWS_ACCESS_TOKEN" get "fbe4ba07-538d-49e2-92dd-b22600c8d9d2" | jq -r .value)
+# resolve config from setup.env / environment, falling back to Bitwarden when a token is available
+requireConfig RENDER_API_CLIENT_ID_DEV
+requireConfig RENDER_API_CLIENT_SECRET_DEV
+requireConfig SENTRY_AUTH_TOKEN
+requireConfig SENTRY_DSN_BACKEND
+requireConfig KEYCLOAK_HOST
+requireConfig KEYCLOAK_PASSWORD
+requireConfig KEYCLOAK_USER
 
 
 ##############################

--- a/scripts/enable-feature-notification-email.sh
+++ b/scripts/enable-feature-notification-email.sh
@@ -14,9 +14,11 @@ set -euo pipefail
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
-source "$baseDirectory/ndb-setup/setup.env"
-source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
-source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
 
 ##############################
 # parse flags
@@ -47,7 +49,10 @@ else
 fi
 resolveInstancePath "$instanceArg" || exit 1
 instance=$(getVar "$path/.env" INSTANCE_NAME)
-[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
+if [ -z "$instance" ]; then
+  instance="$(basename "$path")"
+  instance="${instance#"$PREFIX"}"
+fi
 
 ##############################
 # variables
@@ -147,7 +152,7 @@ adminCredsAvailable=false
 roleAlreadyPresent=false
 if [[ -n "${KEYCLOAK_HOST:-}" && -n "${KEYCLOAK_USER:-}" && -n "${KEYCLOAK_PASSWORD:-}" ]]; then
   adminCredsAvailable=true
-  source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"
+  source "$scriptDir/lib/keycloak.sh"
   if serviceAccountHasRealmManagementRole "$instance" "view-users"; then
     roleAlreadyPresent=true
   fi

--- a/scripts/enable-feature-notification-email.sh
+++ b/scripts/enable-feature-notification-email.sh
@@ -12,9 +12,11 @@ set -euo pipefail
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
+source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
 
 ##############################
 # parse flags
@@ -38,17 +40,19 @@ set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
 ##############################
 
 if [ -n "${1:-}" ]; then
-  instance="$1"
+  instanceArg="$1"
 else
-  echo "What is the name of the instance?"
-  read -r instance
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
 fi
+resolveInstancePath "$instanceArg" || exit 1
+instance=$(getVar "$path/.env" INSTANCE_NAME)
+[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
 
 ##############################
 # variables
 ##############################
 
-path="$baseDirectory/$PREFIX$instance"
 appEnv="$path/config/aam-backend-service/application.env"
 
 ##############################
@@ -130,16 +134,13 @@ ensureRealValue "REPLICATION_BACKEND_KEYCLOAK_CLIENT_ID" "aam-backend" "$path/.e
 keycloakClientId=$(getVar "$path/.env" REPLICATION_BACKEND_KEYCLOAK_CLIENT_ID "aam-backend")
 keycloakClientSecret=$(getVar "$path/.env" REPLICATION_BACKEND_KEYCLOAK_CLIENT_SECRET)
 
-# Resolve Keycloak admin credentials (needed to assign AND verify the realm-management roles). Prefer
-# values from setup.env, otherwise load from BWS. Without them we can neither patch nor verify the role.
-if [[ -z "${KEYCLOAK_HOST:-}" || -z "${KEYCLOAK_USER:-}" || -z "${KEYCLOAK_PASSWORD:-}" ]] && [[ -n "${BWS_ACCESS_TOKEN:-}" ]]; then
-  echo "Loading Keycloak admin credentials from Bitwarden Secrets Manager..."
-  # Best-effort under `set -e`: a failed lookup must not abort the script — an empty value below
-  # simply leaves adminCredsAvailable=false and we continue with a warning.
-  bws config server-base https://vault.bitwarden.eu || true
-  KEYCLOAK_HOST=$(bws secret -t "$BWS_ACCESS_TOKEN" get "3db87144-76c9-4690-8f59-b22600c8c927" | jq -r .value) || true
-  KEYCLOAK_PASSWORD=$(bws secret -t "$BWS_ACCESS_TOKEN" get "c5f42f09-b1c8-43a8-ae75-b22600c8f2e5" | jq -r .value) || true
-  KEYCLOAK_USER=$(bws secret -t "$BWS_ACCESS_TOKEN" get "fbe4ba07-538d-49e2-92dd-b22600c8d9d2" | jq -r .value) || true
+# Resolve Keycloak admin credentials (needed to assign AND verify the realm-management roles). getConfig
+# prefers setup.env / the environment and falls back to BWS when a token is set. Best-effort under
+# `set -e`: a failed lookup leaves the value empty (adminCredsAvailable=false) and we continue with a warning.
+if [[ -z "${KEYCLOAK_HOST:-}" || -z "${KEYCLOAK_USER:-}" || -z "${KEYCLOAK_PASSWORD:-}" ]]; then
+  KEYCLOAK_HOST=$(getConfig KEYCLOAK_HOST || true)
+  KEYCLOAK_USER=$(getConfig KEYCLOAK_USER || true)
+  KEYCLOAK_PASSWORD=$(getConfig KEYCLOAK_PASSWORD || true)
 fi
 
 adminCredsAvailable=false
@@ -216,20 +217,15 @@ backupFile "$appEnv"
 
 # Configure SMTP only when not already set, so re-runs/repairs keep existing (possibly customized) mail settings.
 if [ -z "$existingMailHost" ]; then
-  # Load SMTP credentials from setup.env if set, otherwise fetch from BWS
+  # Resolve SMTP credentials from setup.env / the environment, falling back to BWS (via getConfig).
   if [[ -z "${SMTP_SERVER:-}" || -z "${SMTP_PASSWORD:-}" ]]; then
-    if [[ -z "${BWS_ACCESS_TOKEN:-}" ]]; then
-      echo "ERROR: SMTP_SERVER/SMTP_PASSWORD are not set in setup.env and BWS_ACCESS_TOKEN is not set. Abort."
-      exit 1
-    fi
-    echo "Loading SMTP credentials from Bitwarden Secrets Manager..."
-    # Best-effort under `set -e`: tolerate lookup failures here so the explicit emptiness check
-    # below can report a clear error instead of the script aborting silently.
-    bws config server-base https://vault.bitwarden.eu || true
-    SMTP_SERVER=$(bws secret -t "$BWS_ACCESS_TOKEN" get "55bf05ce-03ed-40fb-8320-b2ce00cf6760" 2>&1 | jq -r '.value // empty') || true
-    SMTP_PASSWORD=$(bws secret -t "$BWS_ACCESS_TOKEN" get "ec5d7f0a-62e3-46d7-a7c7-b2ce00cf8abc" 2>&1 | jq -r '.value // empty') || true
+    # Best-effort under `set -e`: tolerate lookup failures so the explicit emptiness check below can
+    # report a clear error instead of the script aborting silently.
+    SMTP_SERVER=$(getConfig SMTP_SERVER || true)
+    SMTP_PASSWORD=$(getConfig SMTP_PASSWORD || true)
     if [[ -z "$SMTP_SERVER" || -z "$SMTP_PASSWORD" ]]; then
-      echo "ERROR: Failed to load SMTP credentials from Bitwarden. The BWS_ACCESS_TOKEN may not have access to these secrets (they require the production service account token)."
+      echo "ERROR: SMTP_SERVER/SMTP_PASSWORD are not set in setup.env / the environment and could not be"
+      echo "  loaded from Bitwarden (the token may lack access; they require the production service account token). Abort."
       exit 1
     fi
   fi

--- a/scripts/enable-feature-notification.sh
+++ b/scripts/enable-feature-notification.sh
@@ -17,13 +17,13 @@ scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
+source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
 
-# Bitwarden Secrets Manager key names for the shared Firebase project (the same Firebase credentials are used
-# for every instance). Looked up by name via getBwsSecretByKey:
+# FIREBASE_CONFIG_JSON / FIREBASE_CREDENTIAL_BASE64 are resolved via getConfig/requireConfig
+# (setup.env/environment, falling back to Bitwarden Secrets Manager - see lib/secrets.sh). They hold
+# the shared Firebase project's credentials (the same ones are used for every instance):
 #   - the frontend web config (firebase-config.json) the browser uses to register for push notifications
 #   - the backend service-account credential (base64) the aam-backend-service uses to send pushes
-BWS_SECRET_FIREBASE_CONFIG_JSON="FIREBASE_CONFIG_JSON"
-BWS_SECRET_FIREBASE_CREDENTIAL_BASE64="FIREBASE_CREDENTIAL_BASE64"
 
 ##############################
 # parse flags
@@ -62,11 +62,6 @@ instance=$(getVar "$path/.env" INSTANCE_NAME)
 
 appEnv="$path/config/aam-backend-service/application.env"
 
-# Point bws at the EU vault once up front so the secret lookups below work (no-op when no token is set).
-if [ -n "${BWS_ACCESS_TOKEN}" ]; then
-  bws config server-base https://vault.bitwarden.eu
-fi
-
 ##############################
 # script
 ##############################
@@ -90,21 +85,12 @@ if [ "$isFeatureAlreadyEnabled" == "true" ]; then
 fi
 
 # Resolve the backend Firebase service-account credential (base64). Prefer an explicit argument (e.g. for
-# offline/testing), otherwise load it from the Bitwarden Secrets Manager. Because the same shared Firebase
-# project is used for every instance, this is non-interactive and works during automated interactive-setup.
-if [ -n "$2" ]; then
-  configCredentialBase64="$2"
-else
-  if [[ -z "${BWS_ACCESS_TOKEN}" ]]; then
-    echo "BWS_ACCESS_TOKEN is not set and no credential argument was given. Abort."
-    exit 1
-  fi
-  configCredentialBase64=$(getBwsSecretByKey "$BWS_SECRET_FIREBASE_CREDENTIAL_BASE64")
-  if [[ -z "$configCredentialBase64" ]]; then
-    echo "ERROR: Could not load the Firebase credential from Bitwarden (secret '$BWS_SECRET_FIREBASE_CREDENTIAL_BASE64'). Abort."
-    exit 1
-  fi
-fi
+# offline/testing), otherwise load it via getConfig (setup.env/environment, then Bitwarden). Because the same
+# shared Firebase project is used for every instance, this is non-interactive and works during automated
+# interactive-setup.
+[ -n "$2" ] && FIREBASE_CREDENTIAL_BASE64="$2"
+requireConfig FIREBASE_CREDENTIAL_BASE64 "Or pass it as the second argument: ./enable-feature-notification.sh <instance> <credential-base64>"
+configCredentialBase64="$FIREBASE_CREDENTIAL_BASE64"
 
 backupFile "$appEnv"
 
@@ -114,24 +100,20 @@ setEnv "FEATURES_NOTIFICATIONAPI_MODE" "firebase" "$appEnv"
 setEnv "FEATURES_NOTIFICATIONAPI_ENABLED" "true" "$appEnv"
 
 # Write the frontend Firebase web config the browser uses to register for push notifications. Loaded as a
-# single JSON blob from BWS (shared Firebase project) and written to the file docker-compose mounts into the
-# app container (assets/firebase-config.json), replacing the empty template copied during interactive-setup.
-if [ -n "${BWS_ACCESS_TOKEN}" ]; then
-  firebaseConfigJson=$(getBwsSecretByKey "$BWS_SECRET_FIREBASE_CONFIG_JSON")
-  if [[ -z "$firebaseConfigJson" ]]; then
-    echo "WARNING: Could not load firebase-config.json from Bitwarden (secret '$BWS_SECRET_FIREBASE_CONFIG_JSON'); leaving existing file in place."
-  else
-    if ! printf '%s' "$firebaseConfigJson" | jq empty 2>/dev/null; then
-      echo "ERROR: Retrieved firebase-config.json is not valid JSON. Abort."
-      exit 1
-    fi
-
-    backupFile "$path/firebase-config.json"
-    printf '%s' "$firebaseConfigJson" > "$path/firebase-config.json"
-    echo "  ~ wrote firebase-config.json (frontend web push config)"
+# single JSON blob (shared Firebase project) and written to the file docker-compose mounts into the app
+# container (assets/firebase-config.json), replacing the empty template copied during interactive-setup.
+# Non-fatal when unresolved: leave the existing file in place rather than aborting the whole feature enable.
+if firebaseConfigJson=$(getConfig FIREBASE_CONFIG_JSON); then
+  if ! printf '%s' "$firebaseConfigJson" | jq empty 2>/dev/null; then
+    echo "ERROR: Retrieved firebase-config.json is not valid JSON. Abort."
+    exit 1
   fi
+
+  backupFile "$path/firebase-config.json"
+  printf '%s' "$firebaseConfigJson" > "$path/firebase-config.json"
+  echo "  ~ wrote firebase-config.json (frontend web push config)"
 else
-  echo "WARNING: BWS_ACCESS_TOKEN not set; leaving existing firebase-config.json in place."
+  echo "WARNING: Could not resolve firebase-config.json (FIREBASE_CONFIG_JSON not set and not found in Bitwarden); leaving existing file in place."
 fi
 
 # Enable email notifications by default. Always pass --skip-restart: the email step writes its config but does

--- a/scripts/enable-feature-notification.sh
+++ b/scripts/enable-feature-notification.sh
@@ -15,9 +15,11 @@
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
-source "$baseDirectory/ndb-setup/setup.env"
-source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
-source "$baseDirectory/ndb-setup/scripts/lib/secrets.sh"
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
 
 # FIREBASE_CONFIG_JSON / FIREBASE_CREDENTIAL_BASE64 are resolved via getConfig/requireConfig
 # (setup.env/environment, falling back to Bitwarden Secrets Manager - see lib/secrets.sh). They hold
@@ -54,7 +56,10 @@ else
 fi
 resolveInstancePath "$instanceArg" || exit 1
 instance=$(getVar "$path/.env" INSTANCE_NAME)
-[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
+if [ -z "$instance" ]; then
+  instance="$(basename "$path")"
+  instance="${instance#"$PREFIX"}"
+fi
 
 ##############################
 # variables
@@ -118,7 +123,8 @@ fi
 
 # Enable email notifications by default. Always pass --skip-restart: the email step writes its config but does
 # not restart, so the single restart below applies both the notification and email config in one cycle.
-"$baseDirectory/ndb-setup/scripts/enable-feature-notification-email.sh" "$instance" --skip-restart
+# Pass $path (not $instance) so a custom instance location (outside the standard layout) is preserved.
+"$scriptDir/enable-feature-notification-email.sh" "$path" --skip-restart
 
 # Restart once, here, after both this script and the email step have written their config — unless the caller
 # asked to skip it (interactive-setup restarts the stack itself after all enable-* scripts have run).

--- a/scripts/enable-feature-notification.sh
+++ b/scripts/enable-feature-notification.sh
@@ -13,7 +13,8 @@
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 
@@ -46,17 +47,19 @@ set -- "${positionalArgs[@]+"${positionalArgs[@]}"}"
 ##############################
 
 if [ -n "$1" ]; then
-  instance="$1"
+  instanceArg="$1"
 else
-  echo "What is the name of the instance?"
-  read -r instance
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
 fi
+resolveInstancePath "$instanceArg" || exit 1
+instance=$(getVar "$path/.env" INSTANCE_NAME)
+[ -n "$instance" ] || instance="${instanceArg#"$PREFIX"}"
 
 ##############################
 # variables
 ##############################
 
-path="$baseDirectory/$PREFIX$instance"
 appEnv="$path/config/aam-backend-service/application.env"
 
 # Point bws at the EU vault once up front so the secret lookups below work (no-op when no token is set).

--- a/scripts/enable-sentry.sh
+++ b/scripts/enable-sentry.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Enable (or disable) Sentry error logging for an instance.
+# Idempotent: just (re)writes the relevant .env values.
+#
+# Usage:
+#   ./enable-sentry.sh <instance> [y|n]
+#     y (default) -> set the Sentry DSNs and enable logging for app + replication-backend
+#     n           -> disable backend Sentry logging (SENTRY_LOGGING_ENABLED=false)
+#
+# Config (via setup.env / environment, or Bitwarden Secrets Manager when BWS_ACCESS_TOKEN is set):
+#   SENTRY_DSN_APP, SENTRY_DSN_REPLICATION_BACKEND
+
+##############################
+# setup
+##############################
+
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
+
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+
+##############################
+# input
+##############################
+
+if [ -n "$1" ]; then
+  instanceArg="$1"
+else
+  echo "Which instance? (name, or path to the instance directory, e.g. '.')"
+  read -r instanceArg
+fi
+resolveInstancePath "$instanceArg" || exit 1
+if [ ! -d "$path" ]; then
+  echo "ERROR: instance directory not found: $path (run create-instance.sh first). Abort."
+  exit 1
+fi
+org=$(getVar "$path/.env" INSTANCE_NAME)
+
+if [ -n "$2" ]; then
+  enableSentry="$2"
+else
+  echo "Do you want to enable Sentry logging?[y/n]"
+  read -r enableSentry
+fi
+
+##############################
+# script
+##############################
+
+if [ "$enableSentry" == "y" ] || [ "$enableSentry" == "Y" ]; then
+  requireConfig SENTRY_DSN_APP
+  requireConfig SENTRY_DSN_REPLICATION_BACKEND
+  setEnv SENTRY_DSN "$SENTRY_DSN_APP" "$path/.env"
+  setEnv SENTRY_DSN_REPLICATION_BACKEND "$SENTRY_DSN_REPLICATION_BACKEND" "$path/.env"
+  setEnv SENTRY_ENABLED "true" "$path/.env"
+  setEnv SENTRY_ENVIRONMENT "production" "$path/.env"
+  echo "Sentry logging enabled for '$org'."
+else
+  backendEnv="$path/config/aam-backend-service/application.env"
+  if [ -f "$backendEnv" ]; then
+    upsertEnv SENTRY_LOGGING_ENABLED "false" "$backendEnv"
+  fi
+  echo "Sentry logging disabled for '$org'."
+fi

--- a/scripts/interactive-setup.sh
+++ b/scripts/interactive-setup.sh
@@ -162,7 +162,7 @@ if [ "$aamBackendService" == 0 ]; then
   if [ -n "$7" ]; then
     withAamBackendService="$7"
   else
-    echo "Do you want to add aam-backend-services (query-backend)?[y/n]"
+    echo "Do you want to add aam-backend-services (backend APIs)? [y/n]"
     read -r withAamBackendService
   fi
 

--- a/scripts/interactive-setup.sh
+++ b/scripts/interactive-setup.sh
@@ -48,6 +48,10 @@ fi
 # always ensure org is lowercase to avoid problems with keycloak realms being case sensitive
 org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
 
+if ! isValidOrgName "$org"; then
+  echo "Error: The organisation name must be non-empty and contain only lowercase letters, digits, and hyphens (not starting/ending with a hyphen). Please try another one."
+  exit 1
+fi
 if grep -Fxq "$org" "$scriptDir/blacklist.txt"; then
   echo "Error: The organisation name '$org' is blacklisted. Please try another one."
   exit 1
@@ -70,7 +74,10 @@ url=$org.$DOMAIN
 # new-vs-existing instance
 ##############################
 
-app=$(docker ps | grep -ic "$org-app")
+# authoritative check: the instance directory exists once create-instance.sh has run for it, regardless
+# of whether its containers currently happen to be running (docker ps would miss stopped instances)
+app=0
+[ -d "$path" ] && app=1
 
 if [ "$app" != 0 ]; then
   if [ "$startedWithArgs" = true ]; then
@@ -129,6 +136,11 @@ fi
 withPermissions=false
 { [ "$withReplicationBackend" == "y" ] || [ "$withReplicationBackend" == "Y" ]; } && withPermissions=true
 
+# whether the permission backend (replication-backend) is (or will be) active for this instance,
+# either freshly enabled above or already deployed for an existing instance
+permissionBackendActive=false
+{ [ "$withPermissions" = true ] || [ "$replicationBackend" != 0 ]; } && permissionBackendActive=true
+
 ##############################
 # create a new instance
 ##############################
@@ -167,12 +179,18 @@ if [ "$aamBackendService" == 0 ]; then
   fi
 
   if [ "$withAamBackendService" == "y" ] || [ "$withAamBackendService" == "Y" ]; then
-    "$scriptDir/enable-backend.sh" "$org" --skip-restart
+    # enable-backend.sh requires the permission backend (replication-backend) and aborts without it;
+    # reject the combination here instead of discovering it after create-couchdb.sh/keycloak have already run
+    if [ "$permissionBackendActive" != true ]; then
+      echo "ERROR: aam-backend-services requires the permission backend (replication-backend), which is not enabled for '$org'. Skipping backend setup — enable the permission backend first, then rerun enable-backend.sh."
+    else
+      "$scriptDir/enable-backend.sh" "$org" --skip-restart
 
-    # Enabling the backend also enables (push + email) notifications by default. The enable script loads the
-    # Firebase credentials from BWS, so this runs non-interactively. --skip-restart is passed because this
-    # script restarts the stack once at the very end, after all enable-* scripts have written their config.
-    "$scriptDir/enable-feature-notification.sh" "$org" --skip-restart
+      # Enabling the backend also enables (push + email) notifications by default. The enable script loads the
+      # Firebase credentials from BWS, so this runs non-interactively. --skip-restart is passed because this
+      # script restarts the stack once at the very end, after all enable-* scripts have written their config.
+      "$scriptDir/enable-feature-notification.sh" "$org" --skip-restart
+    fi
   fi
 fi
 

--- a/scripts/interactive-setup.sh
+++ b/scripts/interactive-setup.sh
@@ -134,16 +134,17 @@ withPermissions=false
 ##############################
 
 if [ "$app" == 0 ]; then
-  "$scriptDir/create-instance.sh" "$org" "$baseConfig"
-  "$scriptDir/create-keycloak-realm.sh" "$org" "$locale" "$baseConfig"
+  # each step is a prerequisite for the next, so abort the whole setup if any of them fails
+  "$scriptDir/create-instance.sh" "$org" "$baseConfig" || exit 1
+  "$scriptDir/create-keycloak-realm.sh" "$org" "$locale" "$baseConfig" || exit 1
 
   if [ "$withPermissions" = true ]; then
-    "$scriptDir/create-couchdb.sh" "$org" --with-permissions
+    "$scriptDir/create-couchdb.sh" "$org" --with-permissions || exit 1
   else
-    "$scriptDir/create-couchdb.sh" "$org"
+    "$scriptDir/create-couchdb.sh" "$org" || exit 1
   fi
 
-  "$scriptDir/create-initial-user.sh" "$org" "$userEmail" "$userName"
+  "$scriptDir/create-initial-user.sh" "$org" "$userEmail" "$userName" || exit 1
 fi
 
 # switch on the permission backend profile

--- a/scripts/interactive-setup.sh
+++ b/scripts/interactive-setup.sh
@@ -1,80 +1,43 @@
 #!/bin/bash
 
-# This script will create an aam-digital instance.
-# all needed credentials are loaded from the Bitwarden Secrets Manager
-
+# Interactive orchestrator that creates an aam-digital instance end to end.
+# It gathers the answers and then delegates each step to a standalone script (create-dns-record.sh,
+# create-instance.sh, create-keycloak-realm.sh, create-couchdb.sh, create-initial-user.sh, enable-backend.sh,
+# enable-sentry.sh). Each of those can also be run on its own — see the header of each file. Only this
+# interactive entry point requires Bitwarden (BWS_ACCESS_TOKEN); the individual scripts resolve their
+# config from setup.env / the environment and fall back to BWS only when a token is present.
+#
 # how to use
 #
 # make sure to install the dependencies: ./install-dependencies.sh
 #
 # ./interactive-setup.sh <instance> <baseConfig> <locale> <userEmail> <userName> <withReplicationBackend> <withBackend> <createsMonitors> <enableSentry>
 # example: ./interactive-setup.sh qm codo de "mail@foo.bar" "Foo Bar" y y y y
-#
-# Attention: on macos, see setEnv function and enable the macos line instead the linux line
-#
-
 
 ##############################
 # setup
 ##############################
 
-baseDirectory="/var/docker"
-source "$baseDirectory/ndb-setup/setup.env"
-source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
-source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
+ndbSetupDir="$(cd "$scriptDir/.." && pwd)"        # the ndb-setup checkout
 
-# check if BWS_ACCESS_TOKEN is set
+source "$ndbSetupDir/setup.env"
+source "$scriptDir/lib/common.sh"
+source "$scriptDir/lib/secrets.sh"
+
+# the interactive setup relies on Bitwarden for all credentials
 if [[ -z "${BWS_ACCESS_TOKEN}" ]]; then
   echo "BWS_ACCESS_TOKEN is not set. Abort."
   exit 1
 fi
 
-# set server-base to EU instance
-bws config server-base https://vault.bitwarden.eu
-
-# load secrets from Bitwarden Secret Manager
-DNS_HETZNER_API_TOKEN=$(bws secret -t "$BWS_ACCESS_TOKEN" get "1be6f4e3-2abf-4d53-8e13-b22600ace76e" | jq -r .value)
-DNS_HETZNER_ZONE_ID_APP=$(bws secret -t "$BWS_ACCESS_TOKEN" get "f0507ee8-6a72-4dca-b1f1-b22800844dac" | jq -r .value)
-KEYCLOAK_HOST=$(bws secret -t "$BWS_ACCESS_TOKEN" get "3db87144-76c9-4690-8f59-b22600c8c927" | jq -r .value)
-KEYCLOAK_PASSWORD=$(bws secret -t "$BWS_ACCESS_TOKEN" get "c5f42f09-b1c8-43a8-ae75-b22600c8f2e5" | jq -r .value)
-KEYCLOAK_USER=$(bws secret -t "$BWS_ACCESS_TOKEN" get "fbe4ba07-538d-49e2-92dd-b22600c8d9d2" | jq -r .value)
-SENTRY_DSN_APP=$(bws secret -t "$BWS_ACCESS_TOKEN" get "b1b07d2d-05de-41c6-8ac6-b22700766968" | jq -r .value)
-SENTRY_DSN_REPLICATION_BACKEND=$(bws secret -t "$BWS_ACCESS_TOKEN" get "359ea1c0-798e-4e17-ae44-b2e20153051d" | jq -r .value)
-SMTP_SERVER=$(bws secret -t "$BWS_ACCESS_TOKEN" get "55bf05ce-03ed-40fb-8320-b2ce00cf6760" | jq -r .value)
-SMTP_PASSWORD=$(bws secret -t "$BWS_ACCESS_TOKEN" get "ec5d7f0a-62e3-46d7-a7c7-b2ce00cf8abc" | jq -r .value)
+startedWithArgs=false
+[ -n "$1" ] && startedWithArgs=true
 
 ##############################
-# functions
+# organisation name
 ##############################
-
-getKeycloakKey() {
-  keys=$(curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$org/keys" -H "Authorization: Bearer $token")
-  kid=${keys#*\"RS256\":\"}
-  kid=${kid%%\"*}
-  keys=${keys#*\"algorithm\":\"RS256\",}
-  publicKey=${keys#*\"publicKey\":\"}
-  publicKey=${publicKey%%\"*}
-}
-
-# Function to check if the first filename exists, if not, return the second filename
-fileOrDefault() {
-  local primary_file="$1"
-  local default_file="$2"
-
-  if [[ -f "$primary_file" ]]; then
-    echo "$primary_file"
-  else
-    echo "$default_file"
-  fi
-}
-
-##############################
-# script
-##############################
-
-#####
-# Ask Organisation Name
-####
 
 if [ -n "$1" ]; then
   org="$1"
@@ -85,93 +48,41 @@ fi
 # always ensure org is lowercase to avoid problems with keycloak realms being case sensitive
 org=$(echo "$org" | tr '[:upper:]' '[:lower:]')
 
-if grep -Fxq "$org" "$baseDirectory/ndb-setup/scripts/blacklist.txt"; then
-    echo "Error: The organisation name '$org' is blacklisted. Please try another one."
-    exit 1
+if grep -Fxq "$org" "$scriptDir/blacklist.txt"; then
+  echo "Error: The organisation name '$org' is blacklisted. Please try another one."
+  exit 1
 fi
-
-echo "organisation name length: ${#org}"
-
 if [ ${#org} -ge 24 ]; then
-    echo "Error: The organisation name must have less than 24 letters. Please try a shorter one."
-    exit 1
+  echo "Error: The organisation name must have less than 24 letters. Please try a shorter one."
+  exit 1
 fi
-
-#####
-# Set DNS entry
-####
-
-curl -X "POST" "https://dns.hetzner.com/api/v1/records" \
-     -H 'Content-Type: application/json' \
-     -H "Auth-API-Token: $DNS_HETZNER_API_TOKEN" \
-     -d "{
-  \"value\": \"$DNS_SERVER_NAME.aam-digital.net.\",
-  \"type\": \"CNAME\",
-  \"name\": \"$org\",
-  \"zone_id\": \"$DNS_HETZNER_ZONE_ID_APP\"
-}"
-
-#####
-# Create folder for instance if not already existing
-####
 
 path="$baseDirectory/$PREFIX$org"
+url=$org.$DOMAIN
+
+##############################
+# DNS record
+##############################
+
+"$scriptDir/create-dns-record.sh" "$org"
+
+##############################
+# new-vs-existing instance
+##############################
+
 app=$(docker ps | grep -ic "$org-app")
 
-if [ "$app" == 0 ]; then
-  echo "Setting up new instance '$org'"
-  mkdir "$path"
-  cp $baseDirectory/ndb-setup/.env.template "$path/.env"
-  cp $baseDirectory/ndb-setup/couchdb.ini "$path/couchdb.ini"
-  cp $baseDirectory/ndb-setup/config.json "$path/config.json"
-  cp $baseDirectory/ndb-setup/docker-compose.yml "$path/docker-compose.yml"
-  cp $baseDirectory/ndb-setup/firebase-config.json "$path/firebase-config.json"
-  mkdir -p "$path/couchdb/data"
-
-  setEnv INSTANCE_NAME "$org" "$path/.env"
-  setEnv INSTANCE_DOMAIN "$DOMAIN" "$path/.env"
-
-  # setting frontend app version. Using latest available version
-  appVersion=$(curl -s https://api.github.com/repos/Aam-Digital/ndb-core/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')
-  setEnv APP_VERSION "$appVersion" "$path/.env"
-
-  # setting replication-backend version. Using latest available version
-  replicationBackendVersion=$(curl -s https://api.github.com/repos/Aam-Digital/replication-backend/releases | jq -r 'map(select(.name | test("-") | not)) | .[0].name')
-  setEnv AAM_REPLICATION_BACKEND_VERSION "$replicationBackendVersion" "$path/.env"
-
-  # setting backend version. Using latest available version
-  backendVersion=$(getLatestBackendVersion)
-  setEnv AAM_BACKEND_SERVICE_VERSION "$backendVersion" "$path/.env"
-
-  # default couchdb user
-  couchDbUser=aam-admin
-  setEnv COUCHDB_USER "$couchDbUser" "$path/.env"
-
-  couchDbPassword=$(generate_password)
-
-  setEnv COUCHDB_PASSWORD "$couchDbPassword" "$path/.env"
-  echo "CouchDB admin user: $couchDbUser and password: $couchDbPassword"
-
-  setEnv REPLICATION_BACKEND_JWT_SECRET "$(generate_password)" "$path/.env"
-
-  url=$org.$DOMAIN
-
-  setEnv COMPOSE_PROFILES "database-only" "$path/.env"
-
-  echo "App URL: $url"
-else
-  if [ -n "$1" ]; then
-    # When started with args, fail on existing name
+if [ "$app" != 0 ]; then
+  if [ "$startedWithArgs" = true ]; then
     echo "ERROR name already exists"
     exit 1
-  else
-    echo "Instance '$org' already exists"
   fi
+  echo "Instance '$org' already exists"
 fi
 
-#####
-# Ask for baseConfig
-####
+##############################
+# gather remaining answers
+##############################
 
 if [ "$app" == 0 ]; then
   if [ -n "$2" ]; then
@@ -179,27 +90,8 @@ if [ "$app" == 0 ]; then
   else
     echo "Which basic config do you want to include? (e.g. [default], basic, codo, ...)"
     read -r baseConfig
-
-    if [ ! "$baseConfig" ]; then
-      baseConfig=default
-    fi
-
-    if [ ! -d "$baseDirectory/ndb-setup/baseConfigs/$baseConfig" ]; then
-      echo "ERROR Invalid base config '$baseConfig'. Abort."
-      exit 1
-    fi
-
+    [ -n "$baseConfig" ] || baseConfig=default
   fi
-fi
-
-#####
-# Keycloak configuration
-####
-replicationBackend=$(docker ps | grep -c "$org-database") # container only exist, when replication-backend is deployed
-
-setEnv KEYCLOAK_URL "$KEYCLOAK_HOST" "$path/.env"
-
-if [ ! -f "$path/keycloak.json" ]; then
 
   if [ -n "$3" ]; then
     locale="$3"
@@ -208,148 +100,24 @@ if [ ! -f "$path/keycloak.json" ]; then
     read -r locale
   fi
 
-  getKeycloakToken
-
-  # take the custom baseConfig realm file or otherwise the default from keycloak folder
-  keycloakRealmFile=$(fileOrDefault "$baseDirectory/ndb-setup/baseConfigs/$baseConfig/realm_config.json" "$baseDirectory/ndb-setup/keycloak/realm_config.json")
-  # add and replace some customized values
-  keycloakRealmJson=$(jq '
-    .realm = "'"$org"'" |
-    .defaultLocale = "'"$locale"'" |
-    .displayName = "Aam Digital - '"$org"'" |
-    .smtpServer.from = "accounts@aam-digital.com" |
-    .smtpServer.host = "'"$SMTP_SERVER"'" |
-    .smtpServer.port = "587" |
-    .smtpServer.user = "accounts@aam-digital.com" |
-    .smtpServer.password = "'"$SMTP_PASSWORD"'"
-    ' "$keycloakRealmFile")
-
-  # create a realm
-  curl -X "POST" "https://$KEYCLOAK_HOST/admin/realms" \
-       -H "Authorization: Bearer $token" \
-       -H "Content-Type: application/json" \
-       -d "$keycloakRealmJson"
-
-  # create a client
-  clientResponse=$(curl -s -D - -o /dev/null -X POST "https://$KEYCLOAK_HOST/admin/realms/$org/clients" \
-                        -H "Authorization: Bearer $token" \
-                        -H "Content-Type: application/json" \
-                        -d "$(jq '.baseUrl = "https://'"$url"'"' $baseDirectory/ndb-setup/keycloak/client_config.json)")
-
-  # Extrahiere den Location-Header
-  location=$(echo "$clientResponse" | grep -i "^location:")
-
-  # Extrahiere die UUID aus dem Location-Header
-  client=$(echo "$location" | sed -n 's#.*\([a-f0-9]\{8\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{4\}-[a-f0-9]\{12\}\).*#\1#p') # todo mac/linux
-
-  # Get Keycloak config from API
-  getKeycloakKey
-  curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$org/clients/$client/installation/providers/keycloak-oidc-keycloak-json" -H "Authorization: Bearer $token" > "$path/keycloak.json"
-
-  # Set Keycloak public key for bearer auth
-  echo "set publicKey in .env"
-  sed -i "s|^REPLICATION_BACKEND_PUBLIC_KEY=.*|REPLICATION_BACKEND_PUBLIC_KEY=$publicKey|g" "$path/.env" # todo mac/linux
-
-  echo "set kid in .couchdb.ini"
-  sed -i "s/<KID>/$kid/g" "$path/couchdb.ini" # todo mac/linux
-
-  echo "set publicKey in couchdb.ini"
-  sed -i "s|<PUBLIC_KEY>|$publicKey|g" "$path/couchdb.ini" # todo mac/linux
-
-  # wait for DB to be ready
-  (cd "$path" && docker compose up -d)
-  dbContainer="${org}-db-entrypoint"
-  dbLocalUrl="http://127.0.0.1:5984"
-  while [ "$status" != "200" ]; do
-    sleep 4
-    echo "Waiting for DB to be ready"
-    status=$(docker exec "$dbContainer" curl -s -o /dev/null -w "%{http_code}" -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/_up")
-  done
-  docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/_users"
-  docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/app"
-  docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/report-calculation"
-  docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/notification-webhook"
-  docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/app-attachments"
-
   if [ -n "$4" ]; then
     userEmail="$4"
   else
     echo "Email address of initial user"
     read -r userEmail
   fi
+
   if [ -n "$5" ]; then
     userName="$5"
   else
     echo "Name of initial user"
     read -r userName
   fi
-  if [ -n "$userEmail" ] && [ -n "$userName" ]; then
-    curl -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d "{\"username\": \"$userName\",\"enabled\": true,\"email\": \"$userEmail\",\"attributes\": {\"exact_username\": \"User:$userName\"},\"emailVerified\": false,\"credentials\": [], \"requiredActions\": [\"UPDATE_PASSWORD\", \"VERIFY_EMAIL\"]}" "https://$KEYCLOAK_HOST/admin/realms/$org/users"
-    userId=$(curl -s -H "Authorization: Bearer $token" "https://$KEYCLOAK_HOST/admin/realms/$org/users?username=$userName&exact=true")
-    userId=${userId#*\"id\":\"}
-    userId=${userId%%\"*}
-    echo "User id $userId"
-    roles=$(curl -s -H "Authorization: Bearer $token" "https://$KEYCLOAK_HOST/admin/realms/$org/roles")
-    echo "create roles..."
-    curl -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d "$roles" "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/role-mappings/realm"
-    echo "verify email..."
-    # no redirect_uri: Keycloak falls back to the "app" client's baseUrl (set above) for the "back to application" link
-    curl -X PUT -s -H "Authorization: Bearer $token" -H 'Content-Type: application/json' -d '["VERIFY_EMAIL"]' "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/execute-actions-email?client_id=app"
-
-    echo "enable 2fa for user..."
-    roleId=$(curl -X GET "https://$KEYCLOAK_HOST/admin/realms/$org/roles" -H "Authorization: Bearer $token" | jq -r '.[] | select(.name=="no-email-2fa") | .id')
-    echo "$roleId"
-    if [ -z "$roleId" ]; then
-      echo "Fehler: Keine Rolle 'no-email-2fa' gefunden."
-    else
-      curl -X DELETE "https://$KEYCLOAK_HOST/admin/realms/$org/users/$userId/role-mappings/realm" \
-        -H "Authorization: Bearer $token" \
-        -H "Content-Type: application/json" \
-        -d "[{\"id\": \"$roleId\"}]"
-    fi
-
-    echo "create user document in couchdb..."
-    docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" -H 'Content-Type: application/json' -d "{\"name\": \"$userName\"}" "$dbLocalUrl/app/User:$userName"
-  fi
-
-  echo "App is connected with Keycloak"
 fi
 
-#####
-# Apply BaseConfig
-####
-
-if [ "$app" == 0 ]; then
-  if [ -n "$baseConfig" ]; then
-    # to add config or other docs to CouchDB, mount them to the assets/base-configs folder of ndb-core
-    # and use an `available-configs.json` entry to make it selectable in the app
-    # see https://github.com/Aam-Digital/ndb-core/blob/master/src/assets/base-configs/available-configs.json
-
-    if [ -d "$baseDirectory/ndb-setup/baseConfigs/$baseConfig/assets" ]; then
-      $baseDirectory/ndb-setup/scripts/enable-assets-overwrites.sh "$org" "$baseConfig"
-    fi
-
-    # Apply a config overlay shipped by the baseConfig. The baseConfig's `config/` folder mirrors the
-    # instance `config/` tree 1:1 and is copied verbatim, so e.g. a custom notification email template at
-    # `config/aam-backend-service/templates/notification/create-notification-email-template.html` lands at
-    # the path docker-compose mounts into the aam-backend-service container (/opt/app/templates).
-    # Note: this only adds files (e.g. templates/); the per-instance application.env is generated later by
-    # enable-backend.sh, so the two never collide.
-    if [ -d "$baseDirectory/ndb-setup/baseConfigs/$baseConfig/config" ]; then
-      echo "Applying config overlay from baseConfig '$baseConfig'..."
-      mkdir -p "$path/config"
-      cp -r "$baseDirectory/ndb-setup/baseConfigs/$baseConfig/config/." "$path/config/"
-    fi
-  fi
-fi
-
-(cd "$path" && docker compose down && docker stop "$org-db-entrypoint" && docker remove "$org-db-entrypoint")
-echo "The error response above ('No such container...') can be ignored."
-
-#####
-# Ask for permission backend (replication-backend)
-####
-
+# permission backend (replication-backend) — only ask if not already deployed
+replicationBackend=$(docker ps | grep -c "$org-database")
+withReplicationBackend=n
 if [ "$replicationBackend" == 0 ]; then
   if [ -n "$6" ]; then
     withReplicationBackend="$6"
@@ -357,42 +125,38 @@ if [ "$replicationBackend" == 0 ]; then
     echo "Do you want to add the permission backend?[y/n]"
     read -r withReplicationBackend
   fi
+fi
+withPermissions=false
+{ [ "$withReplicationBackend" == "y" ] || [ "$withReplicationBackend" == "Y" ]; } && withPermissions=true
 
-  if [ "$withReplicationBackend" == "y" ] || [ "$withReplicationBackend" == "Y" ]; then
-  setEnv COMPOSE_PROFILES "with-permissions" "$path/.env"
+##############################
+# create a new instance
+##############################
 
-    if [ -f "$path/keycloak.json" ]; then
-      # adjust Keycloak config
-      getKeycloakKey
-    fi
+if [ "$app" == 0 ]; then
+  "$scriptDir/create-instance.sh" "$org" "$baseConfig"
+  "$scriptDir/create-keycloak-realm.sh" "$org" "$locale" "$baseConfig"
 
-    replicationBackend=1
-    echo "replication-backend added"
-  elif [ "$app" == 0 ]; then
-
-    # wait for DB to be ready
-    (cd "$path" && docker compose up -d)
-    dbContainer="${org}-db-entrypoint"
-    dbLocalUrl="http://127.0.0.1:5984"
-
-    while [ "$status" != "200" ]; do
-      sleep 4
-      echo "Waiting for DB to be ready"
-      status=$(docker exec "$dbContainer" curl -s -o /dev/null -w "%{http_code}" -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/_up")
-    done
-
-    docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/app/_security" -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }'
-    docker exec "$dbContainer" curl -s -X PUT -u "$couchDbUser:$couchDbPassword" "$dbLocalUrl/app-attachments/_security" -d '{"admins": { "names": [], "roles": [] }, "members": { "names": [], "roles": ["user_app"] } }'
-
-    (cd "$path" && docker compose down && docker stop "$org-db-entrypoint" && docker remove "$org-db-entrypoint")
+  if [ "$withPermissions" = true ]; then
+    "$scriptDir/create-couchdb.sh" "$org" --with-permissions
+  else
+    "$scriptDir/create-couchdb.sh" "$org"
   fi
+
+  "$scriptDir/create-initial-user.sh" "$org" "$userEmail" "$userName"
 fi
 
-#####
-# Ask for aam-backend
-####
-aamBackendService=$(docker ps | grep -c "$org-aam-backend-service")
+# switch on the permission backend profile
+if [ "$withPermissions" = true ]; then
+  setEnv COMPOSE_PROFILES "with-permissions" "$path/.env"
+  echo "replication-backend added"
+fi
 
+##############################
+# aam-backend (query backend)
+##############################
+
+aamBackendService=$(docker ps | grep -c "$org-aam-backend-service")
 if [ "$aamBackendService" == 0 ]; then
   if [ -n "$7" ]; then
     withAamBackendService="$7"
@@ -402,21 +166,20 @@ if [ "$aamBackendService" == 0 ]; then
   fi
 
   if [ "$withAamBackendService" == "y" ] || [ "$withAamBackendService" == "Y" ]; then
-    $baseDirectory/ndb-setup/scripts/enable-backend.sh "$org" --skip-restart
-    aamBackendService=1
+    "$scriptDir/enable-backend.sh" "$org" --skip-restart
 
     # Enabling the backend also enables (push + email) notifications by default. The enable script loads the
     # Firebase credentials from BWS, so this runs non-interactively. --skip-restart is passed because this
     # script restarts the stack once at the very end, after all enable-* scripts have written their config.
-    $baseDirectory/ndb-setup/scripts/enable-feature-notification.sh "$org" --skip-restart
+    "$scriptDir/enable-feature-notification.sh" "$org" --skip-restart
   fi
 fi
 
-#####
-# Ask for uptime monitoring
-####
+##############################
+# uptime monitoring (deprecated)
+##############################
 
-if [ "$app" == 0 ] && [ "$UPTIMEROBOT_API_KEY" != "" ] && [ "$UPTIMEROBOT_ALERT_ID" != "" ]; then
+if [ "$app" == 0 ] && [ "${UPTIMEROBOT_API_KEY:-}" != "" ] && [ "${UPTIMEROBOT_ALERT_ID:-}" != "" ]; then
   if [ -n "$8" ]; then
     createsMonitors="$8"
   else
@@ -426,7 +189,7 @@ if [ "$app" == 0 ] && [ "$UPTIMEROBOT_API_KEY" != "" ] && [ "$UPTIMEROBOT_ALERT_
 
   if [ "$createsMonitors" == "y" ] || [ "$createsMonitors" == "Y" ]; then
     curl -d "api_key=$UPTIMEROBOT_API_KEY&url=https://$url&friendly_name=Aam - $org App&alert_contacts=$UPTIMEROBOT_ALERT_ID&type=1" -H "Cache-Control: no-cache" -H "Content-Type: application/x-www-form-urlencoded" "https://api.uptimerobot.com/v2/newMonitor" -w "\n"
-    if [ "$replicationBackend" == 1 ]; then
+    if [ "$withPermissions" = true ]; then
       curl -d "api_key=$UPTIMEROBOT_API_KEY&url=https://$url/db/api&friendly_name=Aam - $org Backend&alert_contacts=$UPTIMEROBOT_ALERT_ID&type=1" -H "Cache-Control: no-cache" -H "Content-Type: application/x-www-form-urlencoded" "https://api.uptimerobot.com/v2/newMonitor" -w "\n"
       curl -d "api_key=$UPTIMEROBOT_API_KEY&url=https://$url/db/couchdb/_utils/&friendly_name=Aam - $org DB&alert_contacts=$UPTIMEROBOT_ALERT_ID&type=1" -H "Cache-Control: no-cache" -H "Content-Type: application/x-www-form-urlencoded" "https://api.uptimerobot.com/v2/newMonitor" -w "\n"
     else
@@ -435,9 +198,9 @@ if [ "$app" == 0 ] && [ "$UPTIMEROBOT_API_KEY" != "" ] && [ "$UPTIMEROBOT_ALERT_
   fi
 fi
 
-#####
-# Ask for sentry connection
-####
+##############################
+# Sentry
+##############################
 
 if [ "$app" == 0 ]; then
   if [ -n "$9" ]; then
@@ -446,16 +209,12 @@ if [ "$app" == 0 ]; then
     echo "Do you want to enable Sentry logging?[y/n]"
     read -r enableSentry
   fi
-
-  if [ "$enableSentry" == "y" ] || [ "$enableSentry" == "Y" ]; then
-    setEnv SENTRY_DSN "$SENTRY_DSN_APP" "$path/.env"
-    setEnv SENTRY_DSN_REPLICATION_BACKEND "$SENTRY_DSN_REPLICATION_BACKEND" "$path/.env"
-    setEnv SENTRY_ENABLED "true" "$path/.env"
-    setEnv SENTRY_ENVIRONMENT "production" "$path/.env"
-  else
-    setEnv SENTRY_LOGGING_ENABLED "false" "$path/config/aam-backend-service/application.env"
-  fi
+  "$scriptDir/enable-sentry.sh" "$org" "$enableSentry"
 fi
+
+##############################
+# final restart
+##############################
 
 # Single restart for the whole instance, after every enable-* script (run with --skip-restart) has written
 # its config. `down && up -d` (not just `up -d`) forces recreation so changed env_file/config is picked up.

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -223,6 +223,19 @@ ensureAssetVolumeMountsFromDir() {
 }
 
 ##############################
+# Organisation name validation
+##############################
+
+# Validate an organisation name against the naming contract shared by directory names, DNS labels,
+# Docker container/network names, and Keycloak realm names: non-empty, lowercase letters/digits/hyphens
+# only, must not start or end with a hyphen.
+# Returns 0 (true) if valid, 1 (false) otherwise.
+isValidOrgName() {
+  local name="$1"
+  [[ "$name" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]
+}
+
+##############################
 # Instance path resolution
 ##############################
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -223,6 +223,36 @@ ensureAssetVolumeMountsFromDir() {
 }
 
 ##############################
+# Instance path resolution
+##############################
+
+# Resolve the instance directory from either a name or a path, and set the global `path` (absolute).
+# The first argument is treated as:
+#   - a PATH to the instance directory when it is "." or contains a "/" (e.g. ".", "./c-acme",
+#     "/var/docker/c-acme") — used as-is, so scripts can run against any location without a fixed layout
+#   - otherwise an instance NAME, resolved to "$baseDirectory/$PREFIX<name>" (the standard layout)
+# For the path form the directory must already exist. For the name form it may not (callers that create
+# the instance handle that themselves). Requires baseDirectory + PREFIX for the name form.
+resolveInstancePath() {
+  local arg="$1"
+  case "$arg" in
+    . | */*)
+      path="$(cd "$arg" 2>/dev/null && pwd)"
+      if [ -z "$path" ]; then
+        echo "ERROR: instance directory not found: $arg" >&2
+        return 1
+      fi
+      ;;
+    *)
+      local name
+      name=$(echo "$arg" | tr '[:upper:]' '[:lower:]')
+      name="${name#"$PREFIX"}"   # tolerate the PREFIX being included in the name or not
+      path="$baseDirectory/$PREFIX$name"
+      ;;
+  esac
+}
+
+##############################
 # Instance iteration
 ##############################
 
@@ -230,8 +260,9 @@ ensureAssetVolumeMountsFromDir() {
 # Usage: forEachInstance <callback> [instance]
 #   <callback>  name of a function; called once per instance with the absolute
 #               instance directory as its first argument
-#   [instance]  optional single instance (with or without the PREFIX); when
-#               omitted, iterates every "$baseDirectory/${PREFIX}*" directory
+#   [instance]  optional single instance — an instance NAME (with or without the PREFIX) or a PATH to
+#               the instance directory (incl. "."); see resolveInstancePath. When omitted, iterates
+#               every "$baseDirectory/${PREFIX}*" directory.
 # Requires: $baseDirectory and $PREFIX set (from setup.env).
 # Returns: non-zero if a named instance is missing or PREFIX is unset.
 forEachInstance() {
@@ -239,13 +270,15 @@ forEachInstance() {
   local single="${2:-}"
 
   if [ -n "$single" ]; then
-    # single instance mode (tolerate the prefix being included or not)
-    local path="$baseDirectory/${PREFIX:-}${single#"${PREFIX:-}"}"
-    if [ ! -d "$path" ]; then
-      echo "Instance directory not found: $path"
+    # single instance mode: resolve a name or a path, then capture into a local so callbacks that use a
+    # global `path` are not affected by resolveInstancePath writing to the global `path`.
+    resolveInstancePath "$single" || return 1
+    local dir="$path"
+    if [ ! -d "$dir" ]; then
+      echo "Instance directory not found: $dir"
       return 1
     fi
-    "$callback" "$path"
+    "$callback" "$dir"
     return
   fi
 

--- a/scripts/lib/couchdb.sh
+++ b/scripts/lib/couchdb.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# CouchDB init helpers for ndb-setup scripts.
+# Source after common.sh. All helpers operate on the instance dir in $path and read credentials from its .env.
+#
+# The database-only CouchDB runs as the container "${INSTANCE_NAME}-db-entrypoint". That name is reused by
+# the replication-backend in the permission profiles, so the init container must be removed (couchdbInitStop)
+# before switching profiles. Instance data lives in ./couchdb/data and survives the container removal.
+
+# Start the database-only CouchDB and wait until it answers on /_up.
+# Requires: $path. Sets globals: DB_CONTAINER, DB_LOCAL_URL, DB_USER, DB_PASSWORD.
+couchdbInitStart() {
+  DB_LOCAL_URL="http://127.0.0.1:5984"
+  DB_USER=$(getVar "$path/.env" COUCHDB_USER)
+  DB_PASSWORD=$(getVar "$path/.env" COUCHDB_PASSWORD)
+  DB_CONTAINER="$(getVar "$path/.env" INSTANCE_NAME)-db-entrypoint"
+
+  (cd "$path" && docker compose --profile database-only up -d couchdb-only)
+
+  local status=""
+  while [ "$status" != "200" ]; do
+    sleep 4
+    echo "Waiting for DB to be ready"
+    status=$(docker exec "$DB_CONTAINER" curl -s -o /dev/null -w "%{http_code}" -u "$DB_USER:$DB_PASSWORD" "$DB_LOCAL_URL/_up")
+  done
+}
+
+# Run an authenticated curl against the init container. Extra args are passed to curl.
+# Requires: couchdbInitStart called first.
+couchdbCurl() {
+  docker exec "$DB_CONTAINER" curl -s -u "$DB_USER:$DB_PASSWORD" "$@"
+}
+
+# Remove the temporary init container (idempotent).
+couchdbInitStop() {
+  docker rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
+}

--- a/scripts/lib/couchdb.sh
+++ b/scripts/lib/couchdb.sh
@@ -17,7 +17,14 @@ couchdbInitStart() {
   (cd "$path" && docker compose --profile database-only up -d couchdb-only)
 
   local status=""
+  local attempts=0
+  local maxAttempts=30
   while [ "$status" != "200" ]; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -gt "$maxAttempts" ]; then
+      echo "ERROR: CouchDB did not become ready after $((maxAttempts * 4))s. Abort." >&2
+      return 1
+    fi
     sleep 4
     echo "Waiting for DB to be ready"
     status=$(docker exec "$DB_CONTAINER" curl -s -o /dev/null -w "%{http_code}" -u "$DB_USER:$DB_PASSWORD" "$DB_LOCAL_URL/_up")

--- a/scripts/lib/keycloak.sh
+++ b/scripts/lib/keycloak.sh
@@ -35,6 +35,21 @@ getKeycloakToken() {
   fi
 }
 
+# Fetch a realm's active RS256 signing key (used to configure JWT auth for CouchDB / replication-backend).
+# Requires: KEYCLOAK_HOST, token (call getKeycloakToken first)
+# Sets: kid, publicKey (globals). Returns non-zero if the key could not be determined.
+getKeycloakRealmKey() {
+  local realm="$1"
+  local keys
+  keys=$(curl -s -L "https://$KEYCLOAK_HOST/admin/realms/$realm/keys" -H "Authorization: Bearer $token")
+  kid=$(echo "$keys" | jq -r '.active.RS256 // empty')
+  publicKey=$(echo "$keys" | jq -r --arg kid "$kid" '.keys[] | select(.kid==$kid) | .publicKey // empty')
+  if [ -z "$kid" ] || [ -z "$publicKey" ]; then
+    echo "ERROR: Could not determine active RS256 key for realm '$realm'." >&2
+    return 1
+  fi
+}
+
 # Creates the aam-backend Keycloak client (if it doesn't exist) and assigns required realm-management roles.
 # Requires: KEYCLOAK_HOST, token (call getKeycloakToken first or let this function call it)
 # Sets: clientSecret (global)

--- a/scripts/lib/secrets.sh
+++ b/scripts/lib/secrets.sh
@@ -8,25 +8,19 @@
 # setup.env or the environment — while interactive-setup.sh (and anyone with a token) can keep
 # relying on BWS. See setup.example.env for which values are normally BWS-provided.
 #
-# Requires: jq, and (for the BWS path) the `bws` CLI + BWS_ACCESS_TOKEN.
+# Requires: jq, and (for the BWS path) the `bws` CLI + BWS_ACCESS_TOKEN, plus common.sh sourced
+# first (for getBwsSecretByKey, which looks up secrets by name since bws only supports get-by-id).
 
-# Map a config key to its Bitwarden Secrets Manager secret UUID.
-# A case statement (rather than an associative array) keeps this working on bash 3.2 (macOS).
-_bwsSecretId() {
+# Config keys that are expected to have a same-named secret in Bitwarden Secrets Manager.
+# Lookup is by secret name (via common.sh's getBwsSecretByKey), so this is just a whitelist -
+# a case statement (rather than an associative array) keeps this working on bash 3.2 (macOS).
+_isBwsBackedKey() {
   case "$1" in
-    DNS_HETZNER_API_TOKEN)          echo "1be6f4e3-2abf-4d53-8e13-b22600ace76e" ;;
-    DNS_HETZNER_ZONE_ID_APP)        echo "f0507ee8-6a72-4dca-b1f1-b22800844dac" ;;
-    KEYCLOAK_HOST)                  echo "3db87144-76c9-4690-8f59-b22600c8c927" ;;
-    KEYCLOAK_PASSWORD)              echo "c5f42f09-b1c8-43a8-ae75-b22600c8f2e5" ;;
-    KEYCLOAK_USER)                  echo "fbe4ba07-538d-49e2-92dd-b22600c8d9d2" ;;
-    SENTRY_DSN_APP)                 echo "b1b07d2d-05de-41c6-8ac6-b22700766968" ;;
-    SENTRY_DSN_REPLICATION_BACKEND) echo "359ea1c0-798e-4e17-ae44-b2e20153051d" ;;
-    SENTRY_DSN_BACKEND)             echo "a858a580-9643-4330-8667-b2270073d7a6" ;;
-    SENTRY_AUTH_TOKEN)              echo "b9a3e1eb-3925-4ed6-93f4-b2270073c82c" ;;
-    SMTP_SERVER)                    echo "55bf05ce-03ed-40fb-8320-b2ce00cf6760" ;;
-    SMTP_PASSWORD)                  echo "ec5d7f0a-62e3-46d7-a7c7-b2ce00cf8abc" ;;
-    RENDER_API_CLIENT_ID_DEV)       echo "b53d7a1d-220e-4e07-b1f9-b22700711f79" ;;
-    RENDER_API_CLIENT_SECRET_DEV)   echo "83a8e38b-fc22-461f-91a0-b22700712b62" ;;
+    DNS_HETZNER_API_TOKEN | DNS_HETZNER_ZONE_ID_APP | KEYCLOAK_HOST | KEYCLOAK_PASSWORD | \
+      KEYCLOAK_USER | SENTRY_DSN_APP | SENTRY_DSN_REPLICATION_BACKEND | SENTRY_DSN_BACKEND | \
+      SENTRY_AUTH_TOKEN | SMTP_SERVER | SMTP_PASSWORD | RENDER_API_CLIENT_ID_DEV | \
+      RENDER_API_CLIENT_SECRET_DEV | FIREBASE_CONFIG_JSON | FIREBASE_CREDENTIAL_BASE64)
+      return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -42,7 +36,7 @@ _ensureBwsServer() {
 
 # getConfig KEY
 # Resolve a config value. Order: an existing env/setup.env value, then BWS (only if a token is set
-# and the key has a known secret UUID). Prints the value to stdout; returns non-zero if unresolved.
+# and the key is a known BWS-backed key). Prints the value to stdout; returns non-zero if unresolved.
 getConfig() {
   local key="$1"
 
@@ -53,12 +47,10 @@ getConfig() {
   fi
 
   # 2) Bitwarden Secrets Manager (optional)
-  local uuid
-  if [ -n "${BWS_ACCESS_TOKEN:-}" ] && uuid=$(_bwsSecretId "$key"); then
+  if [ -n "${BWS_ACCESS_TOKEN:-}" ] && _isBwsBackedKey "$key"; then
     _ensureBwsServer
     local value
-    value=$(bws secret -t "$BWS_ACCESS_TOKEN" get "$uuid" 2>/dev/null | jq -r '.value // empty')
-    if [ -n "$value" ]; then
+    if value=$(getBwsSecretByKey "$key"); then
       printf '%s' "$value"
       return 0
     fi
@@ -80,7 +72,7 @@ requireConfig() {
     return 0
   fi
   echo "ERROR: required config '$key' is not set." >&2
-  if _bwsSecretId "$key" >/dev/null; then
+  if _isBwsBackedKey "$key"; then
     echo "  Provide it in setup.env / the environment, or set BWS_ACCESS_TOKEN to load it from Bitwarden." >&2
   else
     echo "  Provide it in setup.env or the environment." >&2

--- a/scripts/lib/secrets.sh
+++ b/scripts/lib/secrets.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Config/secret resolution for ndb-setup scripts.
+#
+# getConfig hides WHERE a value comes from: an already-set environment variable / setup.env value,
+# or the Bitwarden Secrets Manager (only consulted when BWS_ACCESS_TOKEN is available).
+#
+# This lets the standalone scripts run WITHOUT BWS access — just provide the needed values via
+# setup.env or the environment — while interactive-setup.sh (and anyone with a token) can keep
+# relying on BWS. See setup.example.env for which values are normally BWS-provided.
+#
+# Requires: jq, and (for the BWS path) the `bws` CLI + BWS_ACCESS_TOKEN.
+
+# Map a config key to its Bitwarden Secrets Manager secret UUID.
+# A case statement (rather than an associative array) keeps this working on bash 3.2 (macOS).
+_bwsSecretId() {
+  case "$1" in
+    DNS_HETZNER_API_TOKEN)          echo "1be6f4e3-2abf-4d53-8e13-b22600ace76e" ;;
+    DNS_HETZNER_ZONE_ID_APP)        echo "f0507ee8-6a72-4dca-b1f1-b22800844dac" ;;
+    KEYCLOAK_HOST)                  echo "3db87144-76c9-4690-8f59-b22600c8c927" ;;
+    KEYCLOAK_PASSWORD)              echo "c5f42f09-b1c8-43a8-ae75-b22600c8f2e5" ;;
+    KEYCLOAK_USER)                  echo "fbe4ba07-538d-49e2-92dd-b22600c8d9d2" ;;
+    SENTRY_DSN_APP)                 echo "b1b07d2d-05de-41c6-8ac6-b22700766968" ;;
+    SENTRY_DSN_REPLICATION_BACKEND) echo "359ea1c0-798e-4e17-ae44-b2e20153051d" ;;
+    SENTRY_DSN_BACKEND)             echo "a858a580-9643-4330-8667-b2270073d7a6" ;;
+    SENTRY_AUTH_TOKEN)              echo "b9a3e1eb-3925-4ed6-93f4-b2270073c82c" ;;
+    SMTP_SERVER)                    echo "55bf05ce-03ed-40fb-8320-b2ce00cf6760" ;;
+    SMTP_PASSWORD)                  echo "ec5d7f0a-62e3-46d7-a7c7-b2ce00cf8abc" ;;
+    RENDER_API_CLIENT_ID_DEV)       echo "b53d7a1d-220e-4e07-b1f9-b22700711f79" ;;
+    RENDER_API_CLIENT_SECRET_DEV)   echo "83a8e38b-fc22-461f-91a0-b22700712b62" ;;
+    *) return 1 ;;
+  esac
+}
+
+# Point the bws CLI at the EU vault, once per process (no-op without a token).
+_bwsServerConfigured=false
+_ensureBwsServer() {
+  if [ "$_bwsServerConfigured" = false ] && [ -n "${BWS_ACCESS_TOKEN:-}" ]; then
+    bws config server-base https://vault.bitwarden.eu >/dev/null 2>&1
+    _bwsServerConfigured=true
+  fi
+}
+
+# getConfig KEY
+# Resolve a config value. Order: an existing env/setup.env value, then BWS (only if a token is set
+# and the key has a known secret UUID). Prints the value to stdout; returns non-zero if unresolved.
+getConfig() {
+  local key="$1"
+
+  # 1) already provided via environment / setup.env
+  if [ -n "${!key:-}" ]; then
+    printf '%s' "${!key}"
+    return 0
+  fi
+
+  # 2) Bitwarden Secrets Manager (optional)
+  local uuid
+  if [ -n "${BWS_ACCESS_TOKEN:-}" ] && uuid=$(_bwsSecretId "$key"); then
+    _ensureBwsServer
+    local value
+    value=$(bws secret -t "$BWS_ACCESS_TOKEN" get "$uuid" 2>/dev/null | jq -r '.value // empty')
+    if [ -n "$value" ]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# requireConfig KEY [hint]
+# Resolve KEY via getConfig into a same-named exported variable, or abort with a helpful message.
+# After a successful call the value is available as "$KEY" (e.g. requireConfig KEYCLOAK_HOST -> $KEYCLOAK_HOST).
+requireConfig() {
+  local key="$1"
+  local hint="${2:-}"
+  local value
+  if value=$(getConfig "$key"); then
+    printf -v "$key" '%s' "$value"
+    export "$key"
+    return 0
+  fi
+  echo "ERROR: required config '$key' is not set." >&2
+  if _bwsSecretId "$key" >/dev/null; then
+    echo "  Provide it in setup.env / the environment, or set BWS_ACCESS_TOKEN to load it from Bitwarden." >&2
+  else
+    echo "  Provide it in setup.env or the environment." >&2
+  fi
+  [ -n "$hint" ] && echo "  $hint" >&2
+  exit 1
+}

--- a/scripts/migrate-add-sentry-dsn-replication-backend.sh
+++ b/scripts/migrate-add-sentry-dsn-replication-backend.sh
@@ -8,7 +8,8 @@
 set -u
 
 # Load PREFIX, BWS_ACCESS_TOKEN (and other setup.env vars).
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 
 if [ -z "${PREFIX:-}" ]; then

--- a/scripts/migrate-carbone-render-access.sh
+++ b/scripts/migrate-carbone-render-access.sh
@@ -25,7 +25,8 @@
 
 set -uo pipefail
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"

--- a/scripts/migrate-notifications-permission-check.sh
+++ b/scripts/migrate-notifications-permission-check.sh
@@ -15,7 +15,8 @@
 
 set -uo pipefail
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 source "$baseDirectory/ndb-setup/scripts/lib/keycloak.sh"

--- a/scripts/prune-backups.sh
+++ b/scripts/prune-backups.sh
@@ -11,7 +11,8 @@
 
 set -euo pipefail
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 

--- a/scripts/restart-instances.sh
+++ b/scripts/restart-instances.sh
@@ -4,7 +4,8 @@
 #
 # Can be run from any directory.
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 
 for D in "$baseDirectory/${PREFIX}"*; do

--- a/scripts/update-compose.sh
+++ b/scripts/update-compose.sh
@@ -16,7 +16,8 @@
 
 set -euo pipefail
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 

--- a/scripts/version-info.sh
+++ b/scripts/version-info.sh
@@ -5,7 +5,8 @@
 # setup
 ##############################
 
-baseDirectory="/var/docker"
+scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+baseDirectory="$(cd "$scriptDir/../.." && pwd)"   # parent of the ndb-setup checkout (instances live here)
 source "$baseDirectory/ndb-setup/setup.env"
 source "$baseDirectory/ndb-setup/scripts/lib/common.sh"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided, repeatable setup steps for creating instances, provisioning CouchDB/Keycloak, creating the initial admin account, setting DNS records, and enabling/disabling Sentry.
  * Instances and setup steps can be targeted by name or directory and run standalone.
  * Added Keycloak JWT configuration support via `KEYCLOAK_JWT_KID`.
* **Bug Fixes**
  * Improved portability by removing hard-coded base paths and standardizing instance resolution.
* **Documentation**
  * Expanded README setup/deployment guidance and added `scripts/README` describing the setup script system and conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->