### PR TITLE
fix: add sqs-less setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ instance name or path — and, apart from the interactive orchestrator itself, w
 See **[scripts/README.md](./scripts/README.md)** for the architecture, the shared conventions (config
 resolution, name-or-path instance targeting, idempotency) and how to run or extend the scripts.
 
+### Docker Compose Profiles
+
+You can start all or limited backend services using Docker Compose profiles. Set the `COMPOSE_PROFILES` variable in your instance's `.env` file to select which services to deploy:
+
+| Profile | Services | Description | Hierarchy | Setup |
+|---------|----------|-------------|-----------|-------|
+| `database-only` | app + couchdb-only | **Default.** Minimal setup with the frontend app and a standalone CouchDB database. No permission checking. | Base | Set by default when creating a new instance |
+| `with-permissions` | app + couchdb-with-permissions + replication-backend | Adds permission enforcement via the replication-backend service, which proxies all database requests. | Includes `database-only` | Set when adding the permission backend via `interactive_setup.sh` |
+| `full-stack` | everything from `with-permissions` + aam-backend-service + PostgreSQL + RabbitMQ + SQS | Complete backend stack including the aam-backend-service for SQL reports and API integrations, plus its dependencies (PostgreSQL database, RabbitMQ message broker, and SQS for CouchDB change feed processing). | Includes `with-permissions` | Set when enabling backend via `enable-backend.sh` |
+| `full-stack-without-sqs` | everything from `full-stack` except SQS | Same as full-stack but skips SQS (which uses a private Docker image), keeping only public images. | Includes `with-permissions` | Use as alternative to `full-stack` when the SQS image is unavailable |
+
+**Note:** You cannot mix profiles — select one that matches your requirements.
+
+**How to set:**
+```bash
+# In your instance's .env file:
+COMPOSE_PROFILES=full-stack
+
+# Then start the containers:
+docker compose up -d
+```
+
 ---
 
 ## Admin CLI (migrations, statistics, CouchDB operations)
@@ -240,12 +262,14 @@ Consult the [Keycloak docs](https://www.keycloak.org/docs/latest/server_admin/in
 It is possible to calculate reports for the app's data using SQL queries.
 For details information, check our [Report documentation](http://aam-digital.github.io/ndb-core/documentation/additional-documentation/how-to-guides/create-a-report.html)
 
+> This feature requires a propriatary plugin, [Structured Query Service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
+
 ### Set up API Integration
 
 (e.g. with TolaData)
 
 1. Enable the reporting backend:
-   - add `aam-backend-service` to your COMPOSE_PROFILES .env variable to activate that container in the docker compose: `COMPOSE_PROFILES=replication-backend,aam-backend-service`
+   - set `COMPOSE_PROFILES=full-stack` in your instance's `.env` file to activate all backend services including aam-backend-service
    - add `AAM_BACKEND_SERVICE_URL=http://aam-backend-service:3000` to the .env file that feeds into the docker-compose.yml
 2. Set up Reporting API according to [aam-services README](https://github.com/Aam-Digital/aam-services/blob/main/README.md)
    - (re-up the docker compose and confirm the new containers are running)

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Consult the [Keycloak docs](https://www.keycloak.org/docs/latest/server_admin/in
 It is possible to calculate reports for the app's data using SQL queries.
 For details information, check our [Report documentation](http://aam-digital.github.io/ndb-core/documentation/additional-documentation/how-to-guides/create-a-report.html)
 
-> This feature requires a propriatary plugin, [Structured Query Service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
+> This feature requires a proprietary plugin, [Structured Query Service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
 
 ### Set up API Integration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,9 @@ services:
     profiles:
       - with-permissions
       - full-stack
+      - full-stack-without-sqs
 
-  # (optional) replication-backend. Only deployed if "COMPOSE_PROFILES" is "with-permissions" or "full-stack" is set in the `.env` file
+  # (optional) replication-backend. Only deployed if "COMPOSE_PROFILES" is "with-permissions", "full-stack", or "full-stack-without-sqs" is set in the `.env` file
   replication-backend:
     image: ghcr.io/aam-digital/replication-backend:${AAM_REPLICATION_BACKEND_VERSION:-latest}
     container_name: ${INSTANCE_NAME}-db-entrypoint
@@ -106,6 +107,7 @@ services:
     profiles:
       - with-permissions
       - full-stack
+      - full-stack-without-sqs
 
   # (optional) aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" or "full-stack-without-sqs" is set in the `.env` file
   aam-backend-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
       - with-permissions
       - full-stack
 
-  # (optional) aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" is set in the `.env` file
+  # (optional) aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" or "full-stack-without-sqs" is set in the `.env` file
   aam-backend-service:
     image: ghcr.io/aam-digital/aam-backend-service:${AAM_BACKEND_SERVICE_VERSION:-latest}
     container_name: ${INSTANCE_NAME}-aam-backend-service
@@ -147,6 +147,7 @@ services:
     restart: unless-stopped
     profiles:
       - full-stack
+      - full-stack-without-sqs
 
   aam-backend-service-db:
     image: postgres:16.5-bookworm
@@ -162,8 +163,9 @@ services:
     restart: unless-stopped
     profiles:
       - full-stack
+      - full-stack-without-sqs
 
-  # (optional) needed for aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" is set in the `.env` file
+  # (optional) needed for aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" or "full-stack-without-sqs" is set in the `.env` file
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: ${INSTANCE_NAME}-rabbitmq
@@ -182,8 +184,10 @@ services:
       - ./storage/rabbitmq/log:/var/log/rabbitmq
     profiles:
       - full-stack
+      - full-stack-without-sqs
 
   # (optional) needed for aam-backend-service. Only deployed if "COMPOSE_PROFILES" is "full-stack" is set in the `.env` file
+  # Note: SQS is excluded from the full-stack-without-sqs profile (which skips the private SQS image)
   sqs:
     image: ghcr.io/aam-digital/sqs-aam:latest
     container_name: ${INSTANCE_NAME}-sqs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker Compose profiles to selectively deploy backend services.
  * Introduced a `full-stack-without-sqs` profile that runs the stack while intentionally excluding SQS-related components (SQS remains limited to the `full-stack` profile).

* **Documentation**
  * Documented the `COMPOSE_PROFILES` mechanism, including the note that profiles cannot be mixed, plus example setup and startup steps.
  * Clarified that SQS reporting requires a proprietary plugin and updated API integration instructions to use `COMPOSE_PROFILES=full-stack`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->