### PR TITLE
docs: repoint report documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Consult the [Keycloak docs](https://www.keycloak.org/docs/latest/server_admin/in
 ## API Integrations and SQL Reports
 
 It is possible to calculate reports for the app's data using SQL queries.
-For details information, check our [Report documentation](http://aam-digital.github.io/ndb-core/documentation/additional-documentation/how-to-guides/create-a-report.html)
+For details information, check our [Report documentation](https://aam-digital.github.io/ndb-core/documentation/additional-documentation/concepts/reports.html)
 
 > This feature requires a proprietary plugin, [Structured Query Service (SQS)](https://neighbourhood.ie/products-and-services/structured-query-server)
 


### PR DESCRIPTION
- part of Aam-Digital/aam-services#161

Documentation only, one line.

Aam-Digital/ndb-core#4159 moves the reports page from the how-to guides to the concepts section of the frontend documentation, which renames its URL:

```
how-to-guides/create-a-report.html   ->   concepts/reports.html
```

The link in "API Integrations and SQL Reports" is repointed accordingly, and switched from `http` to `https`.

Note on merge order: the new URL only exists once Aam-Digital/ndb-core#4159 is merged and the documentation site is rebuilt.

## Manual Testing Steps

1. Review the one-line change in the "Files changed" tab.
2. After Aam-Digital/ndb-core#4159 is merged, the new link resolves to the "Reports" page under Concepts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Report documentation link to use a secure HTTPS URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->