### PR TITLE
chore(keycloak): move the setup templates to Keycloak 26.7.1

### DIFF
--- a/keycloak/docker-compose.yml
+++ b/keycloak/docker-compose.yml
@@ -3,7 +3,7 @@ name: i-keycloak-dev
 services:
   keycloak:
     # The keycloak-aam image (bundles the aam-theme, 2FA/metrics/third-party, etc.)
-    image: ghcr.io/aam-digital/keycloak-aam:26.4.7-0
+    image: ghcr.io/aam-digital/keycloak-aam:26.7.1-0
     environment:
       # For all available options see https://www.keycloak.org/server/all-config
       KEYCLOAK_ADMIN: admin

--- a/keycloak/docker-compose.yml
+++ b/keycloak/docker-compose.yml
@@ -3,6 +3,8 @@ name: i-keycloak-dev
 services:
   keycloak:
     # The keycloak-aam image (bundles the aam-theme, 2FA/metrics/third-party, etc.)
+    # Published to a private registry, so pulling it requires authentication first:
+    #   docker login ghcr.io   (with a token that has read:packages)
     image: ghcr.io/aam-digital/keycloak-aam:26.7.1-0
     environment:
       # For all available options see https://www.keycloak.org/server/all-config


### PR DESCRIPTION
Moves the Keycloak setup templates to Keycloak 26.7.1, from 26.4.7.

**Blocked until the `26.7.1-0` image is published**, so this stays a draft until then. Nothing else here depends on that.

## Scope

A single line: the image tag in `keycloak/docker-compose.yml`.

Everything else in these templates turned out to need no change, which I checked rather than assumed:

- The startup arguments still parse on 26.7.1, including the login theme argument, with no deprecation warning.
- `KC_HTTP_ENABLED` and `KC_PROXY_HEADERS` behave the same.
- The realm and client templates import cleanly, and the "Email 2FA" browser flow they configure keeps working. That flow depends on two bundled provider extensions, so it is the part most likely to break on a server upgrade, and it does not.
- Wildcard redirect URIs in the client template are still accepted.
- Invitation and verify email links behave exactly as before.

## Verification

A local stack running these templates was seeded on the current version, then upgraded in place to 26.7.1 so the schema migration was part of the test:

| Check | before | after |
|---|---|---|
| Email OTP login, code arrives and is accepted | works | works |
| "Remember this device" skips the second factor next login | works | works |
| User administration calls with the end user's own token | 200 | 200 |
| Invitation / verify email link | single use | single use, unchanged |
| Existing session across the upgrade | n/a | survived |
| Schema migration | n/a | clean |
| ERROR lines during the whole flow | n/a | 0 |

## Manual Testing Steps

1. Wait for the `26.7.1-0` image to be published, then pull it.
2. On an existing installation, back up the Keycloak database first. The schema migration is one way, so going back to the previous tag afterwards is not an option.
3. Bring the stack up and confirm Keycloak starts and the realm is intact.
4. Open the login page and confirm it still carries the Aam Digital styling.
5. Log in as a user who needs the email second factor: password, then the code from the mail. Answer yes to trusting the device, then log in again and confirm no code is requested.
6. Open the user administration screen and confirm listing users and roles works, and that creating a user still sends the invitation mail.

## Notes for later, deliberately not in here

- `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` are deprecated in favour of `KC_BOOTSTRAP_ADMIN_USERNAME` and `KC_BOOTSTRAP_ADMIN_PASSWORD`. They still work, and they log a warning on every start. Worth a separate change so that it is easy to review on its own.
- The Postgres image is pinned to 13.2, which is well behind. Also worth its own change, since a database upgrade is not something to bundle with a Keycloak bump.
- Keycloak logs a deprecation warning about the WebAuthn `requireResidentKey` option. That comes from Keycloak's own realm defaults, not from anything in these templates, so there is nothing to change here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Keycloak container to version 26.7.1.
  * Added documentation clarifying private registry authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->