### PR TITLE
feat: allow instances to be embedded in an iframe by other origins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       # Request a Let's Encrypt certificate for this host (acme-companion).
       # Set only here: the certificate is per-host, shared across all paths.
       LETSENCRYPT_HOST: ${INSTANCE_NAME}.${INSTANCE_DOMAIN}
+      # Other origins that may embed this instance in an iframe (space-separated),
+      # e.g. "https://example.com https://www.example.com". The instance's own origin
+      # is always allowed. Set in the instance's .env only where this is needed.
+      CSP_EXTRA_FRAME_ANCESTORS: ${CSP_EXTRA_FRAME_ANCESTORS:-}
     restart: unless-stopped
 
   couchdb-only:


### PR DESCRIPTION
Passes the new `CSP_EXTRA_FRAME_ANCESTORS` variable through to the `app` container.

## Background

The app image sets `Content-Security-Policy: frame-ancestors` to control which sites may embed an instance in an iframe. Previously it sent `X-Frame-Options: SAMEORIGIN`, which cannot allowlist another origin at all — see Aam-Digital/ndb-core#4284 for the full story (the header only became effective recently, when a syntax error in the nginx template was fixed, which is what broke existing iframe embeds).

## Change

```yaml
CSP_EXTRA_FRAME_ANCESTORS: ${CSP_EXTRA_FRAME_ANCESTORS:-}
```

- Defaults to empty, so **no existing instance changes behaviour** and no `.env.template` change or migration is needed.
- An instance that needs to be embedded elsewhere sets it in its own `.env` as a space-separated list of origins, e.g. `CSP_EXTRA_FRAME_ANCESTORS=https://example.com https://www.example.com`. Scheme + exact host, no path; apex and `www` are different origins and both need listing.
- The instance's own origin is always allowed regardless of this value.

## Sequencing

This is inert until an app image containing Aam-Digital/ndb-core#4284 is deployed, so it can be merged independently and in any order.

## Verification

`docker compose config` with the variable unset resolves it to `""`, and with it set passes the full value through to the `app` service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for allowing additional origins to embed the application in an iframe.
  * The setting accepts space-separated origins and remains empty by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Relates to Aam-Digital/ndb-core#4286
